### PR TITLE
Refactor the lazy named SAOrg to the more formally correct Subscripti…

### DIFF
--- a/scripts/dev_submit_pkg.sh
+++ b/scripts/dev_submit_pkg.sh
@@ -81,7 +81,7 @@ TRIAL_AGREEMENT_ID=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: appli
   ],
   orgs: [
     {
-      role: { id : "'"$ROLE_CONTENT_PROVIDER"'" },
+      role: "Content Provider",
       org: {
         vendorsUuid: "05f327a6-c4d3-43c2-828f-7d6e7e401c97",
         name: "A test content provider org"

--- a/scripts/dev_submit_pkg.sh
+++ b/scripts/dev_submit_pkg.sh
@@ -42,7 +42,7 @@ ISPERPETUAL_YES_RDV=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: appl
 ISPERPETUAL_NO_RDV=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" http://localhost:8080/erm/refdataValues/SubscriptionAgreement/isPerpetual | jq -r '.[] | select(.label=="No") | .id'`
 RENEW_DEFRENEW_RDV=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" http://localhost:8080/erm/refdataValues/SubscriptionAgreement/renewalPriority | jq -r '.[] | select(.label=="Definitely Renew") | .id'`
 RENEW_REVIEW_RDV=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" http://localhost:8080/erm/refdataValues/SubscriptionAgreement/renewalPriority | jq -r '.[] | select(.label=="For Review") | .id'`
-ROLE_CONTENT_PROVIDER=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" http://localhost:8080/erm/refdataValues/SAOrg/role | jq -r '.[] | select(.label=="Content Provider") | .id'`
+ROLE_CONTENT_PROVIDER=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" http://localhost:8080/erm/refdataValues/SubscriptionAgreementOrg/role | jq -r '.[] | select(.label=="Content Provider") | .id'`
 
 # Find the package content item entitle for Clinical Cancer Drugs in K-Int Test Package 001
 CCD_IN_KI_TEST_PKG=`curl --header "X-Okapi-Tenant: diku" "http://localhost:8080/erm/pci?filters=pti.titleInstance.title%3D%3DClinical+Cancer+Drugs&filters=pkg.name%3D%3DK-Int+Test+Package+001" -X GET | jq -r ".[0].id" | tr -d '\r'`

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -55,6 +55,7 @@ dependencies {
 //  compile "org.grails.plugins:views-json-templates"
   console "org.grails:grails-console"
   compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
+  // compile "org.grails.plugins:gorm-graphql:1.0.3.BUILD-SNAPSHOT"
   profile "org.grails.profiles:rest-api"
   runtime "org.glassfish.web:el-impl:2.1.2-b03"
   runtime "com.h2database:h2"

--- a/service/grails-app/conf/logback.groovy
+++ b/service/grails-app/conf/logback.groovy
@@ -33,8 +33,8 @@ logger ('okapi', INFO)
 logger ('folio', DEBUG)
 logger ('org.olf', DEBUG)
 logger ('com.k_int.okapi.OkapiSchemaHandler', WARN)
-logger ('com.k_int.okapi.OkapiClient', DEBUG)
-logger ('org.olf.general.refdata.GrailsDomainRefdataHelpers', DEBUG)
+logger ('com.k_int.okapi.OkapiClient', WARN)
+logger ('org.olf.general.refdata.GrailsDomainRefdataHelpers', WARN)
 
 // Uncomment below logging for output of OKAPI client http.
 //logger 'groovy.net.http.JavaHttpBuilder', DEBUG

--- a/service/grails-app/domain/org/olf/erm/SubscriptionAgreement.groovy
+++ b/service/grails-app/domain/org/olf/erm/SubscriptionAgreement.groovy
@@ -63,7 +63,7 @@ public class SubscriptionAgreement implements MultiTenant<SubscriptionAgreement>
     historyLines: SAEventHistory,
     contacts: InternalContact,
     tags: Tag,
-    orgs: SAOrg
+    orgs: SubscriptionAgreementOrg
   ]
 
   static mappedBy = [

--- a/service/grails-app/domain/org/olf/erm/SubscriptionAgreementOrg.groovy
+++ b/service/grails-app/domain/org/olf/erm/SubscriptionAgreementOrg.groovy
@@ -9,7 +9,7 @@ import org.olf.general.Org
 /**
  * Link a subscription agreement with an org and attach a role
  */
-public class SAOrg implements MultiTenant<SAOrg>{
+public class SubscriptionAgreementOrg implements MultiTenant<SubscriptionAgreementOrg>{
   
   String id
   Org org

--- a/service/grails-app/migrations/initial-model.groovy
+++ b/service/grails-app/migrations/initial-model.groovy
@@ -1,10 +1,10 @@
 databaseChangeLog = {
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-1") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-1") {
         createSequence(sequenceName: "hibernate_sequence")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-2") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-2") {
         createTable(tableName: "boolean_property") {
             column(name: "id", type: "BIGINT") {
                 constraints(nullable: "false")
@@ -12,7 +12,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-3") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-3") {
         createTable(tableName: "content_activation_record") {
             column(name: "car_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -38,7 +38,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-4") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-4") {
         createTable(tableName: "coverage_statement") {
             column(name: "cs_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -68,7 +68,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-5") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-5") {
         createTable(tableName: "entitlement") {
             column(name: "ent_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -92,7 +92,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-6") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-6") {
         createTable(tableName: "erm_resource") {
             column(name: "id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -110,7 +110,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-7") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-7") {
         createTable(tableName: "holdings_coverage") {
             column(name: "co_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -136,7 +136,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-8") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-8") {
         createTable(tableName: "identifier") {
             column(name: "id_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -156,7 +156,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-9") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-9") {
         createTable(tableName: "identifier_namespace") {
             column(name: "idns_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -172,7 +172,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-10") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-10") {
         createTable(tableName: "identifier_occurrence") {
             column(name: "io_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -194,7 +194,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-11") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-11") {
         createTable(tableName: "internal_contact") {
             column(name: "ic_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -214,7 +214,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-12") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-12") {
         createTable(tableName: "node") {
             column(name: "nd_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -244,7 +244,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-13") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-13") {
         createTable(tableName: "org") {
             column(name: "org_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -266,7 +266,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-14") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-14") {
         createTable(tableName: "package") {
             column(name: "id", type: "VARCHAR(255)") {
                 constraints(nullable: "false")
@@ -288,7 +288,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-15") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-15") {
         createTable(tableName: "package_content_item") {
             column(name: "id", type: "VARCHAR(255)") {
                 constraints(nullable: "false")
@@ -318,7 +318,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-16") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-16") {
         createTable(tableName: "platform") {
             column(name: "pt_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -334,7 +334,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-17") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-17") {
         createTable(tableName: "platform_locator") {
             column(name: "pl_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -354,7 +354,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-18") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-18") {
         createTable(tableName: "platform_title_instance") {
             column(name: "id", type: "VARCHAR(255)") {
                 constraints(nullable: "false")
@@ -372,7 +372,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-19") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-19") {
         createTable(tableName: "po_line_proxy") {
             column(name: "pop_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -394,7 +394,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-20") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-20") {
         createTable(tableName: "property") {
             column(autoIncrement: "true", name: "id", type: "BIGINT") {
                 constraints(primaryKey: "true", primaryKeyName: "propertyPK")
@@ -414,7 +414,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-21") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-21") {
         createTable(tableName: "refdata_category") {
             column(name: "rdc_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -430,7 +430,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-22") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-22") {
         createTable(tableName: "refdata_value") {
             column(name: "rdv_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -454,7 +454,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-23") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-23") {
         createTable(tableName: "remotekb") {
             column(name: "rkb_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -496,7 +496,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-24") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-24") {
         createTable(tableName: "sa_event_history") {
             column(name: "eh_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -532,27 +532,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-25") {
-        createTable(tableName: "saorg") {
-            column(name: "sao_id", type: "VARCHAR(36)") {
-                constraints(nullable: "false")
-            }
-
-            column(name: "sao_version", type: "BIGINT") {
-                constraints(nullable: "false")
-            }
-
-            column(name: "sao_org_fk", type: "VARCHAR(36)")
-
-            column(name: "sao_role", type: "VARCHAR(36)")
-
-            column(name: "sao_owner_fk", type: "VARCHAR(36)") {
-                constraints(nullable: "false")
-            }
-        }
-    }
-
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-26") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-25") {
         createTable(tableName: "subscription_agreement") {
             column(name: "sa_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -600,7 +580,27 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-27") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-26") {
+        createTable(tableName: "subscription_agreement_org") {
+            column(name: "sao_id", type: "VARCHAR(36)") {
+                constraints(nullable: "false")
+            }
+
+            column(name: "sao_version", type: "BIGINT") {
+                constraints(nullable: "false")
+            }
+
+            column(name: "sao_org_fk", type: "VARCHAR(36)")
+
+            column(name: "sao_role", type: "VARCHAR(36)")
+
+            column(name: "sao_owner_fk", type: "VARCHAR(36)") {
+                constraints(nullable: "false")
+            }
+        }
+    }
+
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-27") {
         createTable(tableName: "subscription_agreement_tag") {
             column(name: "subscription_agreement_tags_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -610,7 +610,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-28") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-28") {
         createTable(tableName: "tag") {
             column(autoIncrement: "true", name: "id", type: "BIGINT") {
                 constraints(primaryKey: "true", primaryKeyName: "tagPK")
@@ -630,7 +630,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-29") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-29") {
         createTable(tableName: "text_property") {
             column(name: "id", type: "BIGINT") {
                 constraints(nullable: "false")
@@ -638,7 +638,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-30") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-30") {
         createTable(tableName: "title_instance") {
             column(name: "id", type: "VARCHAR(255)") {
                 constraints(nullable: "false")
@@ -648,7 +648,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-31") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-31") {
         createTable(tableName: "work") {
             column(name: "w_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -664,115 +664,115 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-32") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-32") {
         addPrimaryKey(columnNames: "id", constraintName: "boolean_propertyPK", tableName: "boolean_property")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-33") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-33") {
         addPrimaryKey(columnNames: "car_id", constraintName: "content_activation_recordPK", tableName: "content_activation_record")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-34") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-34") {
         addPrimaryKey(columnNames: "cs_id", constraintName: "coverage_statementPK", tableName: "coverage_statement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-35") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-35") {
         addPrimaryKey(columnNames: "ent_id", constraintName: "entitlementPK", tableName: "entitlement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-36") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-36") {
         addPrimaryKey(columnNames: "id", constraintName: "erm_resourcePK", tableName: "erm_resource")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-37") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-37") {
         addPrimaryKey(columnNames: "co_id", constraintName: "holdings_coveragePK", tableName: "holdings_coverage")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-38") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-38") {
         addPrimaryKey(columnNames: "id_id", constraintName: "identifierPK", tableName: "identifier")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-39") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-39") {
         addPrimaryKey(columnNames: "idns_id", constraintName: "identifier_namespacePK", tableName: "identifier_namespace")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-40") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-40") {
         addPrimaryKey(columnNames: "io_id", constraintName: "identifier_occurrencePK", tableName: "identifier_occurrence")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-41") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-41") {
         addPrimaryKey(columnNames: "ic_id", constraintName: "internal_contactPK", tableName: "internal_contact")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-42") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-42") {
         addPrimaryKey(columnNames: "nd_id", constraintName: "nodePK", tableName: "node")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-43") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-43") {
         addPrimaryKey(columnNames: "org_id", constraintName: "orgPK", tableName: "org")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-44") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-44") {
         addPrimaryKey(columnNames: "id", constraintName: "packagePK", tableName: "package")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-45") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-45") {
         addPrimaryKey(columnNames: "id", constraintName: "package_content_itemPK", tableName: "package_content_item")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-46") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-46") {
         addPrimaryKey(columnNames: "pt_id", constraintName: "platformPK", tableName: "platform")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-47") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-47") {
         addPrimaryKey(columnNames: "pl_id", constraintName: "platform_locatorPK", tableName: "platform_locator")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-48") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-48") {
         addPrimaryKey(columnNames: "id", constraintName: "platform_title_instancePK", tableName: "platform_title_instance")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-49") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-49") {
         addPrimaryKey(columnNames: "pop_id", constraintName: "po_line_proxyPK", tableName: "po_line_proxy")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-50") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-50") {
         addPrimaryKey(columnNames: "rdc_id", constraintName: "refdata_categoryPK", tableName: "refdata_category")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-51") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-51") {
         addPrimaryKey(columnNames: "rdv_id", constraintName: "refdata_valuePK", tableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-52") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-52") {
         addPrimaryKey(columnNames: "rkb_id", constraintName: "remotekbPK", tableName: "remotekb")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-53") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-53") {
         addPrimaryKey(columnNames: "eh_id", constraintName: "sa_event_historyPK", tableName: "sa_event_history")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-54") {
-        addPrimaryKey(columnNames: "sao_id", constraintName: "saorgPK", tableName: "saorg")
-    }
-
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-55") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-54") {
         addPrimaryKey(columnNames: "sa_id", constraintName: "subscription_agreementPK", tableName: "subscription_agreement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-56") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-55") {
+        addPrimaryKey(columnNames: "sao_id", constraintName: "subscription_agreement_orgPK", tableName: "subscription_agreement_org")
+    }
+
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-56") {
         addPrimaryKey(columnNames: "id", constraintName: "text_propertyPK", tableName: "text_property")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-57") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-57") {
         addPrimaryKey(columnNames: "id", constraintName: "title_instancePK", tableName: "title_instance")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-58") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-58") {
         addPrimaryKey(columnNames: "w_id", constraintName: "workPK", tableName: "work")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-59") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-59") {
         createIndex(indexName: "rdv_entry_idx", tableName: "refdata_value") {
             column(name: "rdv_value")
 
@@ -780,171 +780,171 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-60") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-60") {
         addForeignKeyConstraint(baseColumnNames: "io_identifier_fk", baseTableName: "identifier_occurrence", constraintName: "FK124sp9vc5hnix1ufo6wi2vbav", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id_id", referencedTableName: "identifier")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-61") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-61") {
         addForeignKeyConstraint(baseColumnNames: "cs_ti_fk", baseTableName: "coverage_statement", constraintName: "FK2ocimr1uh2pogta68xl9ph3n", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "title_instance")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-62") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-62") {
         addForeignKeyConstraint(baseColumnNames: "nd_parent", baseTableName: "node", constraintName: "FK2x99i2kqqt7g2ik5cn2fmif6t", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "nd_id", referencedTableName: "node")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-63") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-63") {
         addForeignKeyConstraint(baseColumnNames: "sa_renewal_priority", baseTableName: "subscription_agreement", constraintName: "FK34wtnrq42y7hiab2pg918y7en", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-64") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-64") {
         addForeignKeyConstraint(baseColumnNames: "sa_content_review_needed", baseTableName: "subscription_agreement", constraintName: "FK4nhteulih6q3nqtsu512ny93x", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-65") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-65") {
         addForeignKeyConstraint(baseColumnNames: "pci_pkg_fk", baseTableName: "package_content_item", constraintName: "FK4u9t780a3pgjy1wxsdn8r131k", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "package")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-66") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-66") {
+        addForeignKeyConstraint(baseColumnNames: "sao_org_fk", baseTableName: "subscription_agreement_org", constraintName: "FK5njhff2krytlio6vtpji5gsg8", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "org_id", referencedTableName: "org")
+    }
+
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-67") {
         addForeignKeyConstraint(baseColumnNames: "sa_agreement_type", baseTableName: "subscription_agreement", constraintName: "FK613exmd4qa6bjjdycx9kot0yp", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-67") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-68") {
         addForeignKeyConstraint(baseColumnNames: "ti_work_fk", baseTableName: "title_instance", constraintName: "FK6jfb5y930akyqphqjt55yrga6", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "w_id", referencedTableName: "work")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-68") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-69") {
         addForeignKeyConstraint(baseColumnNames: "ic_role", baseTableName: "internal_contact", constraintName: "FK6njvotbglvhl7adk4hiv1kbsn", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-69") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-70") {
         addForeignKeyConstraint(baseColumnNames: "ic_owner_fk", baseTableName: "internal_contact", constraintName: "FK7p34rfl5q8gij3717gpkxq4yt", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "sa_id", referencedTableName: "subscription_agreement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-70") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-71") {
         addForeignKeyConstraint(baseColumnNames: "co_ent_fk", baseTableName: "holdings_coverage", constraintName: "FK7tx1qaa6hcl1p5kg4n9k8fv4d", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "ent_id", referencedTableName: "entitlement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-71") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-72") {
+        addForeignKeyConstraint(baseColumnNames: "sao_owner_fk", baseTableName: "subscription_agreement_org", constraintName: "FK7y8hfedonx5ywo6oeu2antqcr", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "sa_id", referencedTableName: "subscription_agreement")
+    }
+
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-73") {
         addForeignKeyConstraint(baseColumnNames: "sa_is_perpetual", baseTableName: "subscription_agreement", constraintName: "FK8g7c4fgbop5kuy91di5eh9luq", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-72") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-74") {
         addForeignKeyConstraint(baseColumnNames: "subscription_agreement_tags_id", baseTableName: "subscription_agreement_tag", constraintName: "FK8gn0bwh4w9184adsq6sj75ir3", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "sa_id", referencedTableName: "subscription_agreement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-73") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-75") {
         addForeignKeyConstraint(baseColumnNames: "pop_owner", baseTableName: "po_line_proxy", constraintName: "FK8ufrte3dhjhseabh067wg08lr", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "ent_id", referencedTableName: "entitlement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-74") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-76") {
         addForeignKeyConstraint(baseColumnNames: "io_status_fk", baseTableName: "identifier_occurrence", constraintName: "FK930t3v9wtioa9a9j5013au5ci", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-75") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-77") {
         addForeignKeyConstraint(baseColumnNames: "eh_event_outcome", baseTableName: "sa_event_history", constraintName: "FK9hxymcjll2kctbwvm60j8ywxv", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-76") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-78") {
         addForeignKeyConstraint(baseColumnNames: "car_target_kb_fk", baseTableName: "content_activation_record", constraintName: "FK9l1k430yfqn9hft2a27kvrv12", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rkb_id", referencedTableName: "remotekb")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-77") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-79") {
         addForeignKeyConstraint(baseColumnNames: "ent_resource_fk", baseTableName: "entitlement", constraintName: "FK9uj3dokm2wv87kfp3vjphnc83", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "erm_resource")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-78") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-80") {
         addForeignKeyConstraint(baseColumnNames: "io_ti_fk", baseTableName: "identifier_occurrence", constraintName: "FKat7yej3qg0w5ppb0t4akj51wl", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "title_instance")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-79") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-81") {
+        addForeignKeyConstraint(baseColumnNames: "sao_role", baseTableName: "subscription_agreement_org", constraintName: "FKbg8mmpb05wmvjlh7b1uyw8e7a", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
+    }
+
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-82") {
         addForeignKeyConstraint(baseColumnNames: "id_ns_fk", baseTableName: "identifier", constraintName: "FKby5jjtajics8edtt193lwtnwv", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "idns_id", referencedTableName: "identifier_namespace")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-80") {
-        addForeignKeyConstraint(baseColumnNames: "sao_role", baseTableName: "saorg", constraintName: "FKc7nh0u9wvonywi7w4688mldm", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
-    }
-
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-81") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-83") {
         addForeignKeyConstraint(baseColumnNames: "car_pti_fk", baseTableName: "content_activation_record", constraintName: "FKcg8khs1ip5xiibdkp85xoe7ba", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "platform_title_instance")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-82") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-84") {
         addForeignKeyConstraint(baseColumnNames: "cs_pci_fk", baseTableName: "coverage_statement", constraintName: "FKciqq54dwgdmv0ta5ugs58sn36", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "package_content_item")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-83") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-85") {
         addForeignKeyConstraint(baseColumnNames: "cs_pti_fk", baseTableName: "coverage_statement", constraintName: "FKdj82640bdcj4dfrbn0aqdgbfp", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "platform_title_instance")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-84") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-86") {
         addForeignKeyConstraint(baseColumnNames: "tag_id", baseTableName: "subscription_agreement_tag", constraintName: "FKe306eyrll9tc7oxd3dataogyj", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "tag")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-85") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-87") {
         addForeignKeyConstraint(baseColumnNames: "pti_ti_fk", baseTableName: "platform_title_instance", constraintName: "FKedoadk035beg5u3vi2232pq9m", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "title_instance")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-86") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-88") {
         addForeignKeyConstraint(baseColumnNames: "res_type_fk", baseTableName: "erm_resource", constraintName: "FKef3ae6ct52nn3jcmqidhhpwf8", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-87") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-89") {
         addForeignKeyConstraint(baseColumnNames: "eh_owner", baseTableName: "sa_event_history", constraintName: "FKeopwa26u1tipqav4a0y01i9sr", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "sa_id", referencedTableName: "subscription_agreement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-88") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-90") {
         addForeignKeyConstraint(baseColumnNames: "res_sub_type_fk", baseTableName: "erm_resource", constraintName: "FKfc1lm4f2parkaa8en9fmo4sqc", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-89") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-91") {
         addForeignKeyConstraint(baseColumnNames: "pl_owner_fk", baseTableName: "platform_locator", constraintName: "FKfn4ls5f77sc18cq9c8owlkgtp", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "pt_id", referencedTableName: "platform")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-90") {
-        addForeignKeyConstraint(baseColumnNames: "sao_owner_fk", baseTableName: "saorg", constraintName: "FKgrupus3g7g354wsng8ywia5bu", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "sa_id", referencedTableName: "subscription_agreement")
-    }
-
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-91") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-92") {
         addForeignKeyConstraint(baseColumnNames: "rdv_owner", baseTableName: "refdata_value", constraintName: "FKh4fon2a7k4y8b2sicjm0i6oy8", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdc_id", referencedTableName: "refdata_category")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-92") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-93") {
         addForeignKeyConstraint(baseColumnNames: "sa_agreement_status", baseTableName: "subscription_agreement", constraintName: "FKiivriw3306iouwpg8e65t3ff0", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-93") {
-        addForeignKeyConstraint(baseColumnNames: "sao_org_fk", baseTableName: "saorg", constraintName: "FKm2prrgpkbihy5gdx8f6g1tjpp", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "org_id", referencedTableName: "org")
-    }
-
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-94") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-94") {
         addForeignKeyConstraint(baseColumnNames: "pkg_remote_kb", baseTableName: "package", constraintName: "FKoedx99aeb9ll9v1p7w29htqtl", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rkb_id", referencedTableName: "remotekb")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-95") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-95") {
         addForeignKeyConstraint(baseColumnNames: "pkg_vendor_fk", baseTableName: "package", constraintName: "FKokps4xbl6ipd7unkfq910jn03", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "org_id", referencedTableName: "org")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-96") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-96") {
         addForeignKeyConstraint(baseColumnNames: "ent_owner_fk", baseTableName: "entitlement", constraintName: "FKoocrauwiw6xp7ace0yueywgqy", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "sa_id", referencedTableName: "subscription_agreement")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-97") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-97") {
         addForeignKeyConstraint(baseColumnNames: "pci_pti_fk", baseTableName: "package_content_item", constraintName: "FKostrwqec52cid7enxbr4b2loe", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "platform_title_instance")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-98") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-98") {
         addForeignKeyConstraint(baseColumnNames: "sa_vendor_fk", baseTableName: "subscription_agreement", constraintName: "FKppeugnj4xts3ah8tjmeg232db", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "org_id", referencedTableName: "org")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-99") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-99") {
         addForeignKeyConstraint(baseColumnNames: "eh_event_type", baseTableName: "sa_event_history", constraintName: "FKs8nxucxkesrpshhxsh15wxdn0", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-100") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-100") {
         addForeignKeyConstraint(baseColumnNames: "pkg_nominal_platform_fk", baseTableName: "package", constraintName: "FKtji5rpd3emxprdidedl006f9u", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "pt_id", referencedTableName: "platform")
     }
 
-    changeSet(author: "ianibbo (generated)", id: "1543333502862-101") {
+    changeSet(author: "ianibbo (generated)", id: "1543400138015-101") {
         addForeignKeyConstraint(baseColumnNames: "pti_pt_fk", baseTableName: "platform_title_instance", constraintName: "FKtlecp40x0sb3rd9w4qi16lcu0", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "pt_id", referencedTableName: "platform")
     }
 }

--- a/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
+++ b/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
@@ -96,7 +96,7 @@ public class TitleInstanceResolverService {
     // If we didn't have a class one identifier AND we weren't able to match anything via
     // a sibling match, try to do a fuzzy match as a last resort
     if ( ( num_matches == 0 ) && ( num_class_one_identifiers == 0 ) ) {
-      // log.debug("No matches on identifier - try a fuzzy text match on title(${citation.title})");
+      log.debug("No matches on identifier - try a fuzzy text match on title(${citation.title})");
       // No matches - try a simple title match
       candidate_list = titleMatch(citation.title,MATCH_THRESHOLD);
       num_matches = candidate_list.size()
@@ -115,7 +115,7 @@ public class TitleInstanceResolverService {
           checkForEnrichment(result, citation);
           break;
         default:
-          log.warn("title matched ${num_matches} records with a threshold >= ${MATCH_THRESHOLD} . Unable to continue. Matching IDs: ${candidate_list.collect { it.id }}");
+          log.warn("title matched ${num_matches} records with a threshold >= ${MATCH_THRESHOLD} . Unable to continue. Matching IDs: ${candidate_list.collect { it.id }}. class one identifier count: ${num_class_one_identifiers}");
           // throw new RuntimeException("Title match returned too many items (${num_matches})");
           break;
       }

--- a/service/grails-app/views/subscriptionAgreement/_subscriptionAgreement.gson
+++ b/service/grails-app/views/subscriptionAgreement/_subscriptionAgreement.gson
@@ -7,4 +7,5 @@ json g.render(subscriptionAgreement, [expand: ['agreementType',
                                                'agreementStatus',
                                                'isPerpetual',
                                                'contentReviewNeeded',
+                                               'orgs',
                                                'vendor']])

--- a/service/grails-app/views/subscriptionAgreementOrg/_subscriptionAgreementOrg.gson
+++ b/service/grails-app/views/subscriptionAgreementOrg/_subscriptionAgreementOrg.gson
@@ -1,0 +1,6 @@
+import groovy.transform.*
+import org.olf.erm.SubscriptionAgreementOrg
+
+@Field SubscriptionAgreementOrg subscriptionAgreementOrg
+json g.render(subscriptionAgreementOrg, [expand: ['role', 'org' ]])
+


### PR DESCRIPTION
…onAgreementOrg, update the gson templates to provide fuller org records

curl --header "X-Okapi-Tenant: diku" http://localhost:8080/erm/sas | jq .

now returns fuller org records:
{
    "id": "ff8081816759d7ab016759de225c0eb3",
    "renewalDate": "2019-01-01T00:01:00Z",
    "contacts": [],
    "tags": [
      {
        "id": 1
      },
      {
        "id": 2
      },
      {
        "id": 3
      }
    ],
    "vendor": {
      "id": "ff8081816759d7ab016759de225c0eb4",
      "vendorsUuid": "05f327a6-c4d3-43c2-828f-7d6e7e401c99",
      "name": "My Super Vendor",
      "sourceURI": "/vendors/some/uri?05f327a6-c4d3-43c2-828f-7d6e7e401c99"
    },
    "renewalPriority": {
      "id": "ff8081816759d7ab016759dc9976000d",
      "value": "for_review",
      "label": "For Review"
    },
    "endDate": "2018-01-31T00:12:00Z",
    "vendorReference": "TRIAL_AVR_001",
    "isPerpetual": {
      "id": "ff8081816759d7ab016759dc998d0010",
      "value": "yes",
      "label": "Yes"
    },
    "startDate": "2018-01-01T00:01:00Z",
    "nextReviewDate": "2018-01-01T00:10:00Z",
    "items": [
      {
        "id": "ff8081816759d7ab016759de225d0eb5"
      }
    ],
    "historyLines": [],
    "name": "Trial Agreement LR 001",
    "localReference": "TRIAL_ALR_001",
    "orgs": [
      {
        "id": "ff8081816759d7ab016759de225d0eb6",
        "org": {
          "id": "ff8081816759d7ab016759de225d0eb7",
          "vendorsUuid": "05f327a6-c4d3-43c2-828f-7d6e7e401c97",
          "name": "A test content provider org"
        },
        "role": {
          "id": "ff8081816759d7ab016759dc9aed001f",
          "value": "content_provider",
          "label": "Content Provider"
        },
        "owner": {
          "id": "ff8081816759d7ab016759de225c0eb3"
        }
      }
    ],
    "agreementStatus": {
      "id": "ff8081816759d7ab016759dc99b90013",
      "value": "draft",
      "label": "Draft"
    },
    "description": "This is a trial agreement"
  }
