### PR TITLE
Added /erm/org route to ModuleDescriptor

### DIFF
--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -86,6 +86,10 @@
           "pathPattern": "/erm/pci/{id}/*"
         },{
           "methods": ["GET"],
+          "pathPattern": "/erm/org",
+          "modulePermissions": [ "vendor.collection.get" ]
+        }, {
+          "methods": ["GET"],
           "pathPattern": "/erm/org/find/{name}",
           "modulePermissions": [ "vendor.collection.get" ]
         },{


### PR DESCRIPTION
Gonna need this (or something like it) for [UIER-23](https://issues.folio.org/browse/UIER-23) so that users can select existing orgs.