### PR TITLE
Added POST route for Orgs

### DIFF
--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -85,7 +85,7 @@
           "methods": ["GET"],
           "pathPattern": "/erm/pci/{id}/*"
         },{
-          "methods": ["GET"],
+          "methods": ["GET", "POST"],
           "pathPattern": "/erm/org",
           "modulePermissions": [ "vendor.collection.get" ]
         }, {


### PR DESCRIPTION
Necessary for [UIER-23](https://issues.folio.org/browse/UIER-23).

The combined combobox approach is a problem due to the issues associated with agreement `orgs` either being specified by a string (if passing an ID) or an object (when passing a name to create an org with). Switching to a two-stage process with a separate "Create Organization" step solves that issue.

Additionally, it'll allow us to immediately verify that an org with a given name doesn't already exist and perform the vendors cross-referencing at the same time. It also _heavily_ cleans up the code.