### PR TITLE
Turned on cascading for SA org deletions

### DIFF
--- a/service/grails-app/domain/org/olf/erm/SubscriptionAgreement.groovy
+++ b/service/grails-app/domain/org/olf/erm/SubscriptionAgreement.groovy
@@ -54,10 +54,10 @@ public class SubscriptionAgreement implements MultiTenant<SubscriptionAgreement>
   Boolean enabled
 
   Org vendor
-  
+
 //  @BindImmutably
   Set<Entitlement> items
-  
+
   static hasMany = [
     items: Entitlement,
     historyLines: SAEventHistory,
@@ -97,6 +97,7 @@ public class SubscriptionAgreement implements MultiTenant<SubscriptionAgreement>
                 contacts cascade: 'all-delete-orphan'
             historyLines cascade: 'all-delete-orphan'
                     tags cascade: 'all-delete-orphan'
+                    orgs cascade: 'all-delete-orphan'
   }
 
   static constraints = {


### PR DESCRIPTION
Was having the same issue as with deletes for the entitlements array where the original response from the PUT was correct but subsequent GETs on the resource weren't. Per convo with @ianibbo, not sure if we're gonna continue with the `_delete` flags for this but figured I'd get this fix in so that the end-to-end system works as expected until we figure out a plan going forward.