### PR TITLE
SubscriptionAgreement: Expand internal contacts

### DIFF
--- a/service/grails-app/views/subscriptionAgreement/_subscriptionAgreement.gson
+++ b/service/grails-app/views/subscriptionAgreement/_subscriptionAgreement.gson
@@ -7,5 +7,6 @@ json g.render(subscriptionAgreement, [expand: ['agreementType',
                                                'agreementStatus',
                                                'isPerpetual',
                                                'contentReviewNeeded',
+                                               'contacts',
                                                'orgs',
                                                'vendor']])


### PR DESCRIPTION
AFAIK this shouldn't be a gigantic array. Expanding it would be a big help in cleaning up the front-end code since we _already_ have to go out to fetch the user info from `/users`.

On a related note, is it possible to have separate expansion rules for when we fetch a list of resources vs a single one? E.g., fetching fewer fields when getting `/erm/sas` than `/erm/sas/1234`?