### PR TITLE
Make entitlements able to refer to external resources

### DIFF
--- a/scripts/dev_submit_pkg.sh
+++ b/scripts/dev_submit_pkg.sh
@@ -118,9 +118,7 @@ ACTIVE_AGREEMENT_ID=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: appl
   },
   items: [
     {
-      authority: 'LPC',
-      reference : "'"$CCD_IN_KI_TEST_PKG"'",
-      label: 'Local Package Cache - Title Clinical Cancer Drugs'
+      resource : { id : "'"$CCD_IN_KI_TEST_PKG"'" }
     }
   ]
 }
@@ -194,11 +192,6 @@ BENTHAM_EXTERNAL_AGREEMENT_ID=`curl --header "X-Okapi-Tenant: diku" -H "Content-
     name:"Bentham Science"
   },
   items: [
-    {
-      authority: 'EKB',
-      reference : '301-3707'
-      label: 'Bentham Science Complete, defined in eHoldings'
-    }
   ]
 }
 ' | jq -r ".id" | tr -d '\r'`

--- a/scripts/dev_submit_pkg.sh
+++ b/scripts/dev_submit_pkg.sh
@@ -225,31 +225,15 @@ RS_KBPLUS_ID=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application
   supportsHarvesting:true
 }
 '`
+# The GOKb_TEST adapter used to be created here - this has moved to the tenant activation section of org.olf.ErmHousekeepingService
 
-echo Add a KB record describing GOKB
+if [ -z "$EBSCO_SANDBOX_CLIENT_ID" ]
+then
+  echo "No Ebsco API credentials set, skipping pull package"
+else
+  echo Add a KB record describing EBSCO sandbox API
 
-# Register a remote source
-RS_GOKB_ID=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X POST http://localhost:8080/erm/kbs -d '
-{
-  name:"GOKb",
-  type:"org.olf.kb.adapters.GOKbOAIAdapter", // K-Int Json Package Format Adapter
-  cursor:null,
-  uri:"https://gokbt.gbv.de/gokb/oai/index/packages",
-  listPrefix:null,
-  fullPrefix:"gokb",
-  principal:null,
-  credentials:null,
-  rectype:"1",
-  active:true,
-  supportsHarvesting:true,
-  activationSupported:false,
-  activationEnabled:false
-}
-'`
-
-echo Add a KB record describing EBSCO sandbox API
-
-RS_EBSCO_ID=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X POST http://localhost:8080/erm/kbs -d '
+  RS_EBSCO_ID=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/json" -X POST http://localhost:8080/erm/kbs -d '
 {
   name:"EBSCO",
   type:"org.olf.kb.adapters.EbscoKBAdapter",
@@ -266,10 +250,6 @@ RS_EBSCO_ID=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: application/
 }
 '`
 
-if [ -z "$EBSCO_SANDBOX_CLIENT_ID" ]
-then
-  echo "No Ebsco API credentials set, skipping pull package"
-else
   echo Import EBSCO Bentham Science Package
   EBSCO_BENTHAM_SCI_ID=`curl --header "X-Okapi-Tenant: diku" -X POST "http://localhost:8080/erm/admin/pullPackage?kb=EBSCO&vendorid=301&packageid=3707" | jq -r ".packageId"  | tr -d '\r'`
   echo Result of loading bentham sci from ebsco: $EBSCO_BENTHAM_SCI_ID.
@@ -278,6 +258,7 @@ else
   # Message from Ian: don't do this without talking to EBSCO first - 
   # EBSCO_ACADEMIC_SOURCE_COMPLETE_ID=`curl --header "X-Okapi-Tenant: diku" -X POST "http://localhost:8080/erm/admin/pullPackage?kb=EBSCO&vendorid=19&packageid=1615" | jq -r ".packageId"  | tr -d '\r'`
   # echo Result of loading academic source complete from ebsco: $EBSCO_ACADEMIC_SOURCE_COMPLETE_ID.
+
 fi
 
 

--- a/scripts/dev_submit_pkg.sh
+++ b/scripts/dev_submit_pkg.sh
@@ -118,7 +118,9 @@ ACTIVE_AGREEMENT_ID=`curl --header "X-Okapi-Tenant: diku" -H "Content-Type: appl
   },
   items: [
     {
-      resource : { id : "'"$CCD_IN_KI_TEST_PKG"'" }
+      authority: 'LPC',
+      reference : "'"$CCD_IN_KI_TEST_PKG"'",
+      label: 'Local Package Cache - Title Clinical Cancer Drugs'
     }
   ]
 }
@@ -192,6 +194,11 @@ BENTHAM_EXTERNAL_AGREEMENT_ID=`curl --header "X-Okapi-Tenant: diku" -H "Content-
     name:"Bentham Science"
   },
   items: [
+    {
+      authority: 'EKB',
+      reference : '301-3707'
+      label: 'Bentham Science Complete, defined in eHoldings'
+    }
   ]
 }
 ' | jq -r ".id" | tr -d '\r'`

--- a/scripts/dev_submit_pkg.sh
+++ b/scripts/dev_submit_pkg.sh
@@ -192,6 +192,8 @@ BENTHAM_EXTERNAL_AGREEMENT_ID=`curl --header "X-Okapi-Tenant: diku" -H "Content-
     name:"Bentham Science"
   },
   items: [
+    { type:"external", authority:"EKB", reference:"301-3707", label:"Bentham Science via eHoldings" },
+    { type:"external", authority:"EKB", reference:"19-1615", label:"Academic Source Complete via eHoldings" },
   ]
 }
 ' | jq -r ".id" | tr -d '\r'`

--- a/scripts/eholdings/create_agreement.sh
+++ b/scripts/eholdings/create_agreement.sh
@@ -1,0 +1,54 @@
+#! /bin/sh
+
+AUTH_TOKEN=`../okapi-login`
+
+STATUS_ACTIVE_RDV=`curl --header "X-Okapi-Tenant: diku" -H "X-Okapi-Token: ${AUTH_TOKEN}" -H "Content-Type: application/json" http://localhost:9130/erm/refdataValues/SubscriptionAgreement/agreementStatus | jq -r '.[] | select(.label=="Active") | .id'`
+
+ISPERPETUAL_NO_RDV=`curl --header "X-Okapi-Tenant: diku" -H "X-Okapi-Token: ${AUTH_TOKEN}" -H "Content-Type: application/json" http://localhost:9130/erm/refdataValues/SubscriptionAgreement/isPerpetual | jq -r '.[] | select(.label=="No") | .id'`
+
+RENEW_DEFRENEW_RDV=`curl --header "X-Okapi-Tenant: diku" -H "X-Okapi-Token: ${AUTH_TOKEN}" -H "Content-Type: application/json" http://localhost:9130/erm/refdataValues/SubscriptionAgreement/renewalPriority | jq -r '.[] | select(.label=="Definitely Renew") | .id'`
+
+echo Looked up the following refdata
+echo active status $STATUS_ACTIVE_RDV
+echo is perpetual $ISPERPETUAL_YES_RDV
+echo renewal $RENEW_DEFRENEW_RDV
+
+echo Create a new agreement, and include an entitement for bentham science defined externally by eholdings
+
+RESP1=`curl --header "X-Okapi-Tenant: diku" -H "X-Okapi-Token: ${AUTH_TOKEN}" -H "Content-Type: application/json" -X POST http://localhost:9130/erm/sas -d ' {
+  name: "EHTC1: Agreement for Bentham and ASC",
+  description: "eHoldings test case 1 - an agreement that will be used to hold entitlements for bentham science and ASC",
+  agreementStatus: { id: "'"$STATUS_ACTIVE_RDV"'" },
+  isPerpetual: { id: "'"$ISPERPETUAL_NO_RDV"'" },
+  renewalPriority: { id: "'"$RENEW_DEFRENEW_RDV"'" },
+  localReference: "EHTC1",
+  startDate: "2019-01-01",
+  items: [
+    { type:"external", authority:"EKB", reference:"301-3707", label:"Bentham Science via eHoldings" }
+  ]
+}
+'`
+
+# echo Result: $RESP1
+
+echo Parse the response we got back from creating the agreement, and extract the agreement ID
+EHTC1=`echo $RESP1 | jq -r ".id" | tr -d '\r'`
+
+echo The ID of our new agreement is $EHTC1
+
+
+echo update that agreement to add ASC
+RESP2=`curl --header "X-Okapi-Tenant: diku" -H "X-Okapi-Token: ${AUTH_TOKEN}" -H "Content-Type: application/json" -X PUT http://localhost:9130/erm/sas/$EHTC1 -d ' {
+    items:[
+      { type:"external", authority:"EKB", reference:"19-1615", label:"Academic Source Complete via eHoldings" }
+    ]
+}
+'`
+
+echo $RESP2
+
+echo You can delete entitlements from the agreement by posting to the items array with the ID of the entitlement to delete, and the extra property _delete:true
+
+echo Search for all agreements where the entitlement reference is 19-1615
+curl --header "X-Okapi-Tenant: diku" "http://localhost:8080/erm/sas?filters=items.reference%3D%3D19-1615&filters=items.authority%3D%3DEKB&stats=true"
+

--- a/service/grails-app/domain/org/olf/erm/Entitlement.groovy
+++ b/service/grails-app/domain/org/olf/erm/Entitlement.groovy
@@ -19,17 +19,13 @@ import grails.gorm.MultiTenant
  * OFTEN attached to an agreement, but it's possible we know we have the right to access a resource
  * without perhaps knowing which agreement controls that right.
  *
- * An entitlement is for a list of content which is defined elsewhere - it may be defined in our local package
- * cache, it might be defined in eHoldings.
- *
  */
 public class Entitlement implements MultiTenant<Entitlement> {
+  public static final Class<? extends ErmResource>[] ALLOWED_RESOURCES = [Pkg, PackageContentItem, PlatformTitleInstance] as Class[]
 
   String id
 
-  String authority
-  String reference
-  String label
+  ErmResource resource
 
   // The date ranges on which this line item is active. These date ranges allow the system to determine
   // what content is "Live" in an agreement. Content can be "Live" without being switched on, and 
@@ -66,9 +62,8 @@ public class Entitlement implements MultiTenant<Entitlement> {
                    id column: 'ent_id', generator: 'uuid', length:36
               version column: 'ent_version'
                 owner column: 'ent_owner_fk'
-            authority column: 'ent_authority'
-            reference column: 'ent_reference'
-                label column: 'ent_label'
+             resource column: 'ent_resource_fk'
+              enabled column: 'ent_enabled'
            activeFrom column: 'ent_active_from'
              activeTo column: 'ent_active_to'
   }
@@ -76,9 +71,12 @@ public class Entitlement implements MultiTenant<Entitlement> {
 
   static constraints = {
         owner(nullable:true,  blank:false)
-    authority(nullable:true,  blank:false)
-    reference(nullable:true,  blank:false)
-        label(nullable:true,  blank:false)
+     resource(nullable:false, blank:false, validator: { val, inst ->
+       Class c = Hibernate.getClass(val)
+       if (!Entitlement.ALLOWED_RESOURCES.contains(c)) {
+         ['allowedTypes', "${c.name}", "entitlement", "resource"]
+       }
+     })
       enabled(nullable:true,  blank:false)
    activeFrom(nullable:true,  blank:false)
      activeTo(nullable:true,  blank:false)

--- a/service/grails-app/domain/org/olf/erm/Entitlement.groovy
+++ b/service/grails-app/domain/org/olf/erm/Entitlement.groovy
@@ -34,6 +34,17 @@ public class Entitlement implements MultiTenant<Entitlement> {
   Date activeFrom
   Date activeTo
 
+  // Type - must be set to external for externally defined packages, null or local for things defined in the local DB
+  String type
+
+  // These three properties allow us to create an entitlement which is externally defined. An externally defined
+  // entitlement does not link to a resource in the tenant database, but instead will use API calls to define
+  // the contents of a package. An example would be Authority:'eHoldings', reference: '301-3707', label 'Bentham science complete
+  // as defined in EKB'
+  String authority
+  String reference
+  String label
+
   static belongsTo = [
     owner:SubscriptionAgreement
   ]
@@ -63,23 +74,39 @@ public class Entitlement implements MultiTenant<Entitlement> {
               version column: 'ent_version'
                 owner column: 'ent_owner_fk'
              resource column: 'ent_resource_fk'
+                 type column: 'ent_type'
               enabled column: 'ent_enabled'
            activeFrom column: 'ent_active_from'
              activeTo column: 'ent_active_to'
+            authority column: 'ent_authority'
+            reference column: 'ent_reference'
+                label column: 'ent_label'
+           
+
   }
 
 
   static constraints = {
         owner(nullable:true,  blank:false)
-     resource(nullable:false, blank:false, validator: { val, inst ->
-       Class c = Hibernate.getClass(val)
-       if (!Entitlement.ALLOWED_RESOURCES.contains(c)) {
-         ['allowedTypes', "${c.name}", "entitlement", "resource"]
+
+     // Now that resources can be internally or externally defined, the internal resource link CAN be null,
+     // but if it is, there should be authorty, reference and label properties.
+     resource(nullable:true, blank:false, validator: { val, inst ->
+       if ( val ) {
+         Class c = Hibernate.getClass(val)
+         if (!Entitlement.ALLOWED_RESOURCES.contains(c)) {
+           ['allowedTypes', "${c.name}", "entitlement", "resource"]
+         }
        }
      })
+
+         type(nullable:true,  blank:false)
       enabled(nullable:true,  blank:false)
    activeFrom(nullable:true,  blank:false)
      activeTo(nullable:true,  blank:false)
+    authority(nullable:true,  blank:false)
+    reference(nullable:true,  blank:false)
+        label(nullable:true,  blank:false)
   }
   
   @Transient

--- a/service/grails-app/domain/org/olf/erm/Entitlement.groovy
+++ b/service/grails-app/domain/org/olf/erm/Entitlement.groovy
@@ -19,13 +19,17 @@ import grails.gorm.MultiTenant
  * OFTEN attached to an agreement, but it's possible we know we have the right to access a resource
  * without perhaps knowing which agreement controls that right.
  *
+ * An entitlement is for a list of content which is defined elsewhere - it may be defined in our local package
+ * cache, it might be defined in eHoldings.
+ *
  */
 public class Entitlement implements MultiTenant<Entitlement> {
-  public static final Class<? extends ErmResource>[] ALLOWED_RESOURCES = [Pkg, PackageContentItem, PlatformTitleInstance] as Class[]
 
   String id
 
-  ErmResource resource
+  String authority
+  String reference
+  String label
 
   // The date ranges on which this line item is active. These date ranges allow the system to determine
   // what content is "Live" in an agreement. Content can be "Live" without being switched on, and 
@@ -62,8 +66,9 @@ public class Entitlement implements MultiTenant<Entitlement> {
                    id column: 'ent_id', generator: 'uuid', length:36
               version column: 'ent_version'
                 owner column: 'ent_owner_fk'
-             resource column: 'ent_resource_fk'
-              enabled column: 'ent_enabled'
+            authority column: 'ent_authority'
+            reference column: 'ent_reference'
+                label column: 'ent_label'
            activeFrom column: 'ent_active_from'
              activeTo column: 'ent_active_to'
   }
@@ -71,12 +76,9 @@ public class Entitlement implements MultiTenant<Entitlement> {
 
   static constraints = {
         owner(nullable:true,  blank:false)
-     resource(nullable:false, blank:false, validator: { val, inst ->
-       Class c = Hibernate.getClass(val)
-       if (!Entitlement.ALLOWED_RESOURCES.contains(c)) {
-         ['allowedTypes', "${c.name}", "entitlement", "resource"]
-       }
-     })
+    authority(nullable:true,  blank:false)
+    reference(nullable:true,  blank:false)
+        label(nullable:true,  blank:false)
       enabled(nullable:true,  blank:false)
    activeFrom(nullable:true,  blank:false)
      activeTo(nullable:true,  blank:false)

--- a/service/grails-app/domain/org/olf/kb/ErmResource.groovy
+++ b/service/grails-app/domain/org/olf/kb/ErmResource.groovy
@@ -7,6 +7,7 @@ import grails.gorm.MultiTenant
 
 /**
  * an ErmResource - Superclass
+ * Represents a selectable resource - a package, a title in a package, a title on a platform, etc
  */
 public class ErmResource implements MultiTenant<ErmResource> {
  

--- a/service/grails-app/domain/org/olf/kb/RemoteKB.groovy
+++ b/service/grails-app/domain/org/olf/kb/RemoteKB.groovy
@@ -27,6 +27,8 @@ public class RemoteKB implements MultiTenant<RemoteKB> {
   String credentials
   Long rectype  // 1-PACKAGE
 
+  public static final Long RECTYPE_PACKAGE = new Long(1);
+
   // Harvesting role
   /** Does this remote KB support harvesting */
   Boolean supportsHarvesting

--- a/service/grails-app/migrations/initial-model.groovy
+++ b/service/grails-app/migrations/initial-model.groovy
@@ -1,10 +1,10 @@
 databaseChangeLog = {
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-1") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-1") {
         createSequence(sequenceName: "hibernate_sequence")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-2") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-2") {
         createTable(tableName: "content_activation_record") {
             column(name: "car_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -30,7 +30,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-3") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-3") {
         createTable(tableName: "coverage_statement") {
             column(name: "cs_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -60,7 +60,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-4") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-4") {
         createTable(tableName: "custom_property") {
             column(autoIncrement: "true", name: "id", type: "BIGINT") {
                 constraints(primaryKey: "true", primaryKeyName: "custom_propertyPK")
@@ -76,7 +76,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-5") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-5") {
         createTable(tableName: "custom_property_blob") {
             column(name: "id", type: "BIGINT") {
                 constraints(nullable: "false")
@@ -88,7 +88,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-6") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-6") {
         createTable(tableName: "custom_property_boolean") {
             column(name: "id", type: "BIGINT") {
                 constraints(nullable: "false")
@@ -100,7 +100,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-7") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-7") {
         createTable(tableName: "custom_property_container") {
             column(name: "id", type: "BIGINT") {
                 constraints(nullable: "false")
@@ -108,7 +108,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-8") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-8") {
         createTable(tableName: "custom_property_decimal") {
             column(name: "id", type: "BIGINT") {
                 constraints(nullable: "false")
@@ -120,7 +120,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-9") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-9") {
         createTable(tableName: "custom_property_definition") {
             column(name: "pd_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -142,7 +142,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-10") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-10") {
         createTable(tableName: "custom_property_integer") {
             column(name: "id", type: "BIGINT") {
                 constraints(nullable: "false")
@@ -154,7 +154,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-11") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-11") {
         createTable(tableName: "custom_property_refdata") {
             column(name: "id", type: "BIGINT") {
                 constraints(nullable: "false")
@@ -166,7 +166,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-12") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-12") {
         createTable(tableName: "custom_property_refdata_definition") {
             column(name: "pd_id", type: "VARCHAR(255)") {
                 constraints(nullable: "false")
@@ -178,7 +178,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-13") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-13") {
         createTable(tableName: "custom_property_text") {
             column(name: "id", type: "BIGINT") {
                 constraints(nullable: "false")
@@ -190,7 +190,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-14") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-14") {
         createTable(tableName: "entitlement") {
             column(name: "ent_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -204,17 +204,23 @@ databaseChangeLog = {
 
             column(name: "ent_owner_fk", type: "VARCHAR(36)")
 
-            column(name: "ent_resource_fk", type: "VARCHAR(36)") {
-                constraints(nullable: "false")
-            }
+            column(name: "ent_resource_fk", type: "VARCHAR(36)")
 
             column(name: "ent_active_from", type: "timestamp")
 
+            column(name: "ent_authority", type: "VARCHAR(255)")
+
+            column(name: "ent_type", type: "VARCHAR(255)")
+
             column(name: "ent_enabled", type: "BOOLEAN")
+
+            column(name: "ent_label", type: "VARCHAR(255)")
+
+            column(name: "ent_reference", type: "VARCHAR(255)")
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-15") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-15") {
         createTable(tableName: "erm_resource") {
             column(name: "id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -232,7 +238,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-16") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-16") {
         createTable(tableName: "holdings_coverage") {
             column(name: "co_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -258,7 +264,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-17") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-17") {
         createTable(tableName: "identifier") {
             column(name: "id_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -278,7 +284,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-18") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-18") {
         createTable(tableName: "identifier_namespace") {
             column(name: "idns_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -294,7 +300,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-19") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-19") {
         createTable(tableName: "identifier_occurrence") {
             column(name: "io_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -316,7 +322,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-20") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-20") {
         createTable(tableName: "internal_contact") {
             column(name: "ic_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -336,7 +342,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-21") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-21") {
         createTable(tableName: "node") {
             column(name: "nd_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -366,7 +372,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-22") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-22") {
         createTable(tableName: "org") {
             column(name: "org_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -388,7 +394,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-23") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-23") {
         createTable(tableName: "package") {
             column(name: "id", type: "VARCHAR(255)") {
                 constraints(nullable: "false")
@@ -410,7 +416,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-24") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-24") {
         createTable(tableName: "package_content_item") {
             column(name: "id", type: "VARCHAR(255)") {
                 constraints(nullable: "false")
@@ -440,7 +446,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-25") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-25") {
         createTable(tableName: "platform") {
             column(name: "pt_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -456,7 +462,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-26") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-26") {
         createTable(tableName: "platform_locator") {
             column(name: "pl_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -476,7 +482,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-27") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-27") {
         createTable(tableName: "platform_title_instance") {
             column(name: "id", type: "VARCHAR(255)") {
                 constraints(nullable: "false")
@@ -494,7 +500,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-28") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-28") {
         createTable(tableName: "po_line_proxy") {
             column(name: "pop_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -516,7 +522,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-29") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-29") {
         createTable(tableName: "refdata_category") {
             column(name: "rdc_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -532,7 +538,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-30") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-30") {
         createTable(tableName: "refdata_value") {
             column(name: "rdv_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -556,7 +562,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-31") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-31") {
         createTable(tableName: "remotekb") {
             column(name: "rkb_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -566,17 +572,19 @@ databaseChangeLog = {
                 constraints(nullable: "false")
             }
 
-            column(name: "rkb_creds", type: "VARCHAR(255)")
-
             column(name: "rkb_cursor", type: "VARCHAR(255)")
 
             column(name: "rkb_activation_supported", type: "BOOLEAN")
 
+            column(name: "rkb_active", type: "BOOLEAN")
+
+            column(name: "rkb_activation_enabled", type: "BOOLEAN")
+
+            column(name: "rkb_creds", type: "VARCHAR(255)")
+
             column(name: "rkb_name", type: "VARCHAR(255)") {
                 constraints(nullable: "false")
             }
-
-            column(name: "rkb_active", type: "BOOLEAN")
 
             column(name: "rkb_type", type: "VARCHAR(255)")
 
@@ -585,8 +593,6 @@ databaseChangeLog = {
             column(name: "rkb_list_prefix", type: "VARCHAR(255)")
 
             column(name: "rkb_full_prefix", type: "VARCHAR(255)")
-
-            column(name: "rkb_activation_enabled", type: "BOOLEAN")
 
             column(name: "rkb_uri", type: "VARCHAR(255)")
 
@@ -598,7 +604,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-32") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-32") {
         createTable(tableName: "sa_event_history") {
             column(name: "eh_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -634,7 +640,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-33") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-33") {
         createTable(tableName: "subscription_agreement") {
             column(name: "sa_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -682,7 +688,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-34") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-34") {
         createTable(tableName: "subscription_agreement_org") {
             column(name: "sao_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -702,7 +708,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-35") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-35") {
         createTable(tableName: "subscription_agreement_tag") {
             column(name: "subscription_agreement_tags_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -712,7 +718,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-36") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-36") {
         createTable(tableName: "tag") {
             column(autoIncrement: "true", name: "id", type: "BIGINT") {
                 constraints(primaryKey: "true", primaryKeyName: "tagPK")
@@ -732,7 +738,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-37") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-37") {
         createTable(tableName: "title_instance") {
             column(name: "id", type: "VARCHAR(255)") {
                 constraints(nullable: "false")
@@ -742,7 +748,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-38") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-38") {
         createTable(tableName: "work") {
             column(name: "w_id", type: "VARCHAR(36)") {
                 constraints(nullable: "false")
@@ -758,147 +764,147 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-39") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-39") {
         addPrimaryKey(columnNames: "car_id", constraintName: "content_activation_recordPK", tableName: "content_activation_record")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-40") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-40") {
         addPrimaryKey(columnNames: "cs_id", constraintName: "coverage_statementPK", tableName: "coverage_statement")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-41") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-41") {
         addPrimaryKey(columnNames: "id", constraintName: "custom_property_blobPK", tableName: "custom_property_blob")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-42") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-42") {
         addPrimaryKey(columnNames: "id", constraintName: "custom_property_booleanPK", tableName: "custom_property_boolean")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-43") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-43") {
         addPrimaryKey(columnNames: "id", constraintName: "custom_property_containerPK", tableName: "custom_property_container")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-44") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-44") {
         addPrimaryKey(columnNames: "id", constraintName: "custom_property_decimalPK", tableName: "custom_property_decimal")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-45") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-45") {
         addPrimaryKey(columnNames: "pd_id", constraintName: "custom_property_definitionPK", tableName: "custom_property_definition")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-46") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-46") {
         addPrimaryKey(columnNames: "id", constraintName: "custom_property_integerPK", tableName: "custom_property_integer")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-47") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-47") {
         addPrimaryKey(columnNames: "id", constraintName: "custom_property_refdataPK", tableName: "custom_property_refdata")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-48") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-48") {
         addPrimaryKey(columnNames: "pd_id", constraintName: "custom_property_refdata_definitionPK", tableName: "custom_property_refdata_definition")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-49") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-49") {
         addPrimaryKey(columnNames: "id", constraintName: "custom_property_textPK", tableName: "custom_property_text")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-50") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-50") {
         addPrimaryKey(columnNames: "ent_id", constraintName: "entitlementPK", tableName: "entitlement")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-51") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-51") {
         addPrimaryKey(columnNames: "id", constraintName: "erm_resourcePK", tableName: "erm_resource")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-52") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-52") {
         addPrimaryKey(columnNames: "co_id", constraintName: "holdings_coveragePK", tableName: "holdings_coverage")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-53") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-53") {
         addPrimaryKey(columnNames: "id_id", constraintName: "identifierPK", tableName: "identifier")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-54") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-54") {
         addPrimaryKey(columnNames: "idns_id", constraintName: "identifier_namespacePK", tableName: "identifier_namespace")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-55") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-55") {
         addPrimaryKey(columnNames: "io_id", constraintName: "identifier_occurrencePK", tableName: "identifier_occurrence")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-56") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-56") {
         addPrimaryKey(columnNames: "ic_id", constraintName: "internal_contactPK", tableName: "internal_contact")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-57") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-57") {
         addPrimaryKey(columnNames: "nd_id", constraintName: "nodePK", tableName: "node")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-58") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-58") {
         addPrimaryKey(columnNames: "org_id", constraintName: "orgPK", tableName: "org")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-59") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-59") {
         addPrimaryKey(columnNames: "id", constraintName: "packagePK", tableName: "package")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-60") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-60") {
         addPrimaryKey(columnNames: "id", constraintName: "package_content_itemPK", tableName: "package_content_item")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-61") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-61") {
         addPrimaryKey(columnNames: "pt_id", constraintName: "platformPK", tableName: "platform")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-62") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-62") {
         addPrimaryKey(columnNames: "pl_id", constraintName: "platform_locatorPK", tableName: "platform_locator")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-63") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-63") {
         addPrimaryKey(columnNames: "id", constraintName: "platform_title_instancePK", tableName: "platform_title_instance")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-64") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-64") {
         addPrimaryKey(columnNames: "pop_id", constraintName: "po_line_proxyPK", tableName: "po_line_proxy")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-65") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-65") {
         addPrimaryKey(columnNames: "rdc_id", constraintName: "refdata_categoryPK", tableName: "refdata_category")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-66") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-66") {
         addPrimaryKey(columnNames: "rdv_id", constraintName: "refdata_valuePK", tableName: "refdata_value")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-67") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-67") {
         addPrimaryKey(columnNames: "rkb_id", constraintName: "remotekbPK", tableName: "remotekb")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-68") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-68") {
         addPrimaryKey(columnNames: "eh_id", constraintName: "sa_event_historyPK", tableName: "sa_event_history")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-69") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-69") {
         addPrimaryKey(columnNames: "sa_id", constraintName: "subscription_agreementPK", tableName: "subscription_agreement")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-70") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-70") {
         addPrimaryKey(columnNames: "sao_id", constraintName: "subscription_agreement_orgPK", tableName: "subscription_agreement_org")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-71") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-71") {
         addPrimaryKey(columnNames: "id", constraintName: "title_instancePK", tableName: "title_instance")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-72") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-72") {
         addPrimaryKey(columnNames: "w_id", constraintName: "workPK", tableName: "work")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-73") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-73") {
         addUniqueConstraint(columnNames: "pd_name", constraintName: "UC_CUSTOM_PROPERTY_DEFINITIONPD_NAME_COL", tableName: "custom_property_definition")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-74") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-74") {
         createIndex(indexName: "identifier_value_idx", tableName: "identifier") {
             column(name: "id_ns_fk")
 
@@ -906,7 +912,7 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-75") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-75") {
         createIndex(indexName: "rdv_entry_idx", tableName: "refdata_value") {
             column(name: "rdv_value")
 
@@ -914,193 +920,193 @@ databaseChangeLog = {
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-76") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-76") {
         createIndex(indexName: "td_type_idx", tableName: "custom_property_definition") {
             column(name: "pd_type")
         }
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-77") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-77") {
         addForeignKeyConstraint(baseColumnNames: "io_identifier_fk", baseTableName: "identifier_occurrence", constraintName: "FK124sp9vc5hnix1ufo6wi2vbav", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id_id", referencedTableName: "identifier")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-78") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-78") {
         addForeignKeyConstraint(baseColumnNames: "cs_ti_fk", baseTableName: "coverage_statement", constraintName: "FK2ocimr1uh2pogta68xl9ph3n", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "title_instance")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-79") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-79") {
         addForeignKeyConstraint(baseColumnNames: "nd_parent", baseTableName: "node", constraintName: "FK2x99i2kqqt7g2ik5cn2fmif6t", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "nd_id", referencedTableName: "node")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-80") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-80") {
         addForeignKeyConstraint(baseColumnNames: "sa_renewal_priority", baseTableName: "subscription_agreement", constraintName: "FK34wtnrq42y7hiab2pg918y7en", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-81") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-81") {
         addForeignKeyConstraint(baseColumnNames: "definition_id", baseTableName: "custom_property", constraintName: "FK36grvth72fb7wu5i5xaeqjitw", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "pd_id", referencedTableName: "custom_property_definition")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-82") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-82") {
         addForeignKeyConstraint(baseColumnNames: "sa_content_review_needed", baseTableName: "subscription_agreement", constraintName: "FK4nhteulih6q3nqtsu512ny93x", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-83") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-83") {
         addForeignKeyConstraint(baseColumnNames: "pci_pkg_fk", baseTableName: "package_content_item", constraintName: "FK4u9t780a3pgjy1wxsdn8r131k", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "package")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-84") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-84") {
         addForeignKeyConstraint(baseColumnNames: "sao_org_fk", baseTableName: "subscription_agreement_org", constraintName: "FK5njhff2krytlio6vtpji5gsg8", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "org_id", referencedTableName: "org")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-85") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-85") {
         addForeignKeyConstraint(baseColumnNames: "value_id", baseTableName: "custom_property_refdata", constraintName: "FK5ogn0fedwxxy4fhmq9du4qej2", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-86") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-86") {
         addForeignKeyConstraint(baseColumnNames: "sa_agreement_type", baseTableName: "subscription_agreement", constraintName: "FK613exmd4qa6bjjdycx9kot0yp", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-87") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-87") {
         addForeignKeyConstraint(baseColumnNames: "ti_work_fk", baseTableName: "title_instance", constraintName: "FK6jfb5y930akyqphqjt55yrga6", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "w_id", referencedTableName: "work")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-88") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-88") {
         addForeignKeyConstraint(baseColumnNames: "ic_role", baseTableName: "internal_contact", constraintName: "FK6njvotbglvhl7adk4hiv1kbsn", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-89") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-89") {
         addForeignKeyConstraint(baseColumnNames: "ic_owner_fk", baseTableName: "internal_contact", constraintName: "FK7p34rfl5q8gij3717gpkxq4yt", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "sa_id", referencedTableName: "subscription_agreement")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-90") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-90") {
         addForeignKeyConstraint(baseColumnNames: "co_ent_fk", baseTableName: "holdings_coverage", constraintName: "FK7tx1qaa6hcl1p5kg4n9k8fv4d", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "ent_id", referencedTableName: "entitlement")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-91") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-91") {
         addForeignKeyConstraint(baseColumnNames: "sao_owner_fk", baseTableName: "subscription_agreement_org", constraintName: "FK7y8hfedonx5ywo6oeu2antqcr", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "sa_id", referencedTableName: "subscription_agreement")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-92") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-92") {
         addForeignKeyConstraint(baseColumnNames: "sa_is_perpetual", baseTableName: "subscription_agreement", constraintName: "FK8g7c4fgbop5kuy91di5eh9luq", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-93") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-93") {
         addForeignKeyConstraint(baseColumnNames: "subscription_agreement_tags_id", baseTableName: "subscription_agreement_tag", constraintName: "FK8gn0bwh4w9184adsq6sj75ir3", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "sa_id", referencedTableName: "subscription_agreement")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-94") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-94") {
         addForeignKeyConstraint(baseColumnNames: "pop_owner", baseTableName: "po_line_proxy", constraintName: "FK8ufrte3dhjhseabh067wg08lr", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "ent_id", referencedTableName: "entitlement")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-95") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-95") {
         addForeignKeyConstraint(baseColumnNames: "io_status_fk", baseTableName: "identifier_occurrence", constraintName: "FK930t3v9wtioa9a9j5013au5ci", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-96") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-96") {
         addForeignKeyConstraint(baseColumnNames: "eh_event_outcome", baseTableName: "sa_event_history", constraintName: "FK9hxymcjll2kctbwvm60j8ywxv", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-97") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-97") {
         addForeignKeyConstraint(baseColumnNames: "car_target_kb_fk", baseTableName: "content_activation_record", constraintName: "FK9l1k430yfqn9hft2a27kvrv12", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rkb_id", referencedTableName: "remotekb")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-98") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-98") {
         addForeignKeyConstraint(baseColumnNames: "ent_resource_fk", baseTableName: "entitlement", constraintName: "FK9uj3dokm2wv87kfp3vjphnc83", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "erm_resource")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-99") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-99") {
         addForeignKeyConstraint(baseColumnNames: "io_ti_fk", baseTableName: "identifier_occurrence", constraintName: "FKat7yej3qg0w5ppb0t4akj51wl", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "title_instance")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-100") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-100") {
         addForeignKeyConstraint(baseColumnNames: "sao_role", baseTableName: "subscription_agreement_org", constraintName: "FKbg8mmpb05wmvjlh7b1uyw8e7a", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-101") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-101") {
         addForeignKeyConstraint(baseColumnNames: "category_id", baseTableName: "custom_property_refdata_definition", constraintName: "FKbrh88caagajlvrpaydg4tr3qx", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdc_id", referencedTableName: "refdata_category")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-102") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-102") {
         addForeignKeyConstraint(baseColumnNames: "id_ns_fk", baseTableName: "identifier", constraintName: "FKby5jjtajics8edtt193lwtnwv", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "idns_id", referencedTableName: "identifier_namespace")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-103") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-103") {
         addForeignKeyConstraint(baseColumnNames: "car_pti_fk", baseTableName: "content_activation_record", constraintName: "FKcg8khs1ip5xiibdkp85xoe7ba", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "platform_title_instance")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-104") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-104") {
         addForeignKeyConstraint(baseColumnNames: "cs_pci_fk", baseTableName: "coverage_statement", constraintName: "FKciqq54dwgdmv0ta5ugs58sn36", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "package_content_item")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-105") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-105") {
         addForeignKeyConstraint(baseColumnNames: "parent_id", baseTableName: "custom_property", constraintName: "FKd5u2tgpracxvk1xw8pdreuj5h", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "custom_property_container")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-106") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-106") {
         addForeignKeyConstraint(baseColumnNames: "cs_pti_fk", baseTableName: "coverage_statement", constraintName: "FKdj82640bdcj4dfrbn0aqdgbfp", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "platform_title_instance")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-107") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-107") {
         addForeignKeyConstraint(baseColumnNames: "tag_id", baseTableName: "subscription_agreement_tag", constraintName: "FKe306eyrll9tc7oxd3dataogyj", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "tag")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-108") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-108") {
         addForeignKeyConstraint(baseColumnNames: "pti_ti_fk", baseTableName: "platform_title_instance", constraintName: "FKedoadk035beg5u3vi2232pq9m", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "title_instance")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-109") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-109") {
         addForeignKeyConstraint(baseColumnNames: "res_type_fk", baseTableName: "erm_resource", constraintName: "FKef3ae6ct52nn3jcmqidhhpwf8", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-110") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-110") {
         addForeignKeyConstraint(baseColumnNames: "eh_owner", baseTableName: "sa_event_history", constraintName: "FKeopwa26u1tipqav4a0y01i9sr", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "sa_id", referencedTableName: "subscription_agreement")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-111") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-111") {
         addForeignKeyConstraint(baseColumnNames: "res_sub_type_fk", baseTableName: "erm_resource", constraintName: "FKfc1lm4f2parkaa8en9fmo4sqc", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-112") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-112") {
         addForeignKeyConstraint(baseColumnNames: "pl_owner_fk", baseTableName: "platform_locator", constraintName: "FKfn4ls5f77sc18cq9c8owlkgtp", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "pt_id", referencedTableName: "platform")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-113") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-113") {
         addForeignKeyConstraint(baseColumnNames: "rdv_owner", baseTableName: "refdata_value", constraintName: "FKh4fon2a7k4y8b2sicjm0i6oy8", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdc_id", referencedTableName: "refdata_category")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-114") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-114") {
         addForeignKeyConstraint(baseColumnNames: "sa_agreement_status", baseTableName: "subscription_agreement", constraintName: "FKiivriw3306iouwpg8e65t3ff0", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-115") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-115") {
         addForeignKeyConstraint(baseColumnNames: "pkg_remote_kb", baseTableName: "package", constraintName: "FKoedx99aeb9ll9v1p7w29htqtl", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rkb_id", referencedTableName: "remotekb")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-116") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-116") {
         addForeignKeyConstraint(baseColumnNames: "pkg_vendor_fk", baseTableName: "package", constraintName: "FKokps4xbl6ipd7unkfq910jn03", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "org_id", referencedTableName: "org")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-117") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-117") {
         addForeignKeyConstraint(baseColumnNames: "ent_owner_fk", baseTableName: "entitlement", constraintName: "FKoocrauwiw6xp7ace0yueywgqy", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "sa_id", referencedTableName: "subscription_agreement")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-118") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-118") {
         addForeignKeyConstraint(baseColumnNames: "pci_pti_fk", baseTableName: "package_content_item", constraintName: "FKostrwqec52cid7enxbr4b2loe", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "id", referencedTableName: "platform_title_instance")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-119") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-119") {
         addForeignKeyConstraint(baseColumnNames: "sa_vendor_fk", baseTableName: "subscription_agreement", constraintName: "FKppeugnj4xts3ah8tjmeg232db", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "org_id", referencedTableName: "org")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-120") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-120") {
         addForeignKeyConstraint(baseColumnNames: "eh_event_type", baseTableName: "sa_event_history", constraintName: "FKs8nxucxkesrpshhxsh15wxdn0", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-121") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-121") {
         addForeignKeyConstraint(baseColumnNames: "pkg_nominal_platform_fk", baseTableName: "package", constraintName: "FKtji5rpd3emxprdidedl006f9u", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "pt_id", referencedTableName: "platform")
     }
 
-    changeSet(author: "sosguthorpe (generated)", id: "1545064873683-122") {
+    changeSet(author: "ibbo (generated)", id: "1548415620875-122") {
         addForeignKeyConstraint(baseColumnNames: "pti_pt_fk", baseTableName: "platform_title_instance", constraintName: "FKtlecp40x0sb3rd9w4qi16lcu0", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "pt_id", referencedTableName: "platform")
     }
 }

--- a/service/grails-app/services/org/olf/ErmHousekeepingService.groovy
+++ b/service/grails-app/services/org/olf/ErmHousekeepingService.groovy
@@ -25,14 +25,39 @@ public class ErmHousekeepingService {
 
   private void setupData(tenantName, tenantId) {
 
+    log.info("ErmHousekeepingService::setupData(${tenantName},${tenantId})");
+
     // leaving this here as an example - it works, but we don't actually want to do this in practice!
     Tenants.withId(tenantId) {
 
       // A special record for packages which are really defined locally - this is an exceptional situation
       RemoteKB local_kb = RemoteKB.findByName('LOCAL') ?: new RemoteKB( name:'LOCAL',
-                                                                        rectype: new Long(1),
-                                                                        active:Boolean.TRUE).save(flush:true, failOnError:true);
-    
+                                                                        rectype: RemoteKB.RECTYPE_PACKAGE,
+                                                                        active:Boolean.TRUE,
+                                                                        supportsHarvesting:false,
+                                                                        activationEnabled:false).save(flush:true, failOnError:true);
+
+      RemoteKB gokb_test = RemoteKB.findByName('GOKb_TEST') ?: new RemoteKB( name:'GOKb_TEST',
+                                                                        type:'org.olf.kb.adapters.GOKbOAIAdapter',
+                                                                        uri:'http://gokbt.gbv.de/gokb/oai/index/packages',
+                                                                        fullPrefix:'gokb',
+                                                                        rectype: RemoteKB.RECTYPE_PACKAGE,
+                                                                        active:Boolean.TRUE,
+                                                                        supportsHarvesting:true,
+                                                                        activationEnabled:false).save(flush:true, failOnError:true);
+
+      RemoteKB ebsco_live = RemoteKB.findByName('EBSCO_API') ?: new RemoteKB( name:'EBSCO_LIVE',
+                                                                        type:'org.olf.kb.adapters.EbscoKBAdapter',
+                                                                        uri:'https://sandbox.ebsco.io',
+                                                                        principal:'YOUR_CLIENT_ID',
+                                                                        credentials:'YOUR_API_KEY',
+                                                                        rectype: RemoteKB.RECTYPE_PACKAGE,
+                                                                        active:Boolean.FALSE,
+                                                                        supportsHarvesting:false,
+                                                                        activationSupported:true,
+                                                                        activationEnabled:false).save(flush:true, failOnError:true);
+
+
     }
   }
 }

--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -165,7 +165,7 @@ public class PackageIngestService {
               pci.save(flush:true, failOnError:true);
             }
             catch ( Exception e ) {
-              log.error("[${rowum}] problem",e);
+              log.error("[${rownum}] problem",e);
             }
           }
           else {

--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -213,13 +213,18 @@ public class PackageIngestService {
     // this is how we detect deletions in the package file.
     log.debug("end of packageUpsert. Remove any content items that have disappeared since the last upload. ${pkg.name}/${pkg.source}/${pkg.reference}/${result.updateTime}");
     int removal_counter = 0;
-    PackageContentItem.executeQuery('select pci from PackageContentItem as pci where pci.pkg = :pkg and pci.lastSeenTimestamp < :updateTime',[pkg:pkg, updateTime:result.updateTime]).each { removal_candidate ->
-      log.debug("Removal candidate: pci.id #${removal_candidate.id} (Last seen ${removal_candidate.lastSeenTimestamp}, thisUpdate ${result.updateTime}) -- Set removed");
-      removal_candidate.removedTimestamp = result.updateTime;
-      removal_candidate.save(flush:true, failOnError:true);
-      removal_counter++;
+    
+    PackageContentItem.withNewTransaction { status ->
+      PackageContentItem.executeQuery('select pci from PackageContentItem as pci where pci.pkg = :pkg and pci.lastSeenTimestamp < :updateTime',
+                                      [pkg:pkg, updateTime:result.updateTime]).each { removal_candidate ->
+        log.debug("Removal candidate: pci.id #${removal_candidate.id} (Last seen ${removal_candidate.lastSeenTimestamp}, thisUpdate ${result.updateTime}) -- Set removed");
+        removal_candidate.removedTimestamp = result.updateTime;
+        removal_candidate.save(flush:true, failOnError:true);
+        removal_counter++;
+      }
+      log.debug("${removal_counter} removed");
+      result.numTitlesRemoved = removal_counter;
     }
-    log.debug("${removal_counter} removed");
 
     return result;
   }

--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -85,6 +85,7 @@ public class PackageIngestService {
     }
 
     package_data.packageContents.each { pc ->
+
       // log.debug("Try to resolve ${pc}");
 
       try {
@@ -165,7 +166,7 @@ public class PackageIngestService {
               pci.save(flush:true, failOnError:true);
             }
             catch ( Exception e ) {
-              log.error("[${rownum}] problem",e);
+              log.error("[${result.titleCount}] problem",e);
             }
           }
           else {

--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -18,6 +18,12 @@ import org.olf.general.Org
 @Transactional
 public class PackageIngestService {
 
+  // This boolean controls the behaviour of the loader when we encounter a title that does not have
+  // a platform URL. We can error the row and do nothing, or create a row and point it at a proxy
+  // platform to flag the error. Currently trialling the latter case. set to false to error and ignore the
+  // row.
+  private boolean PROXY_MISSING_PLATFORM = true;
+
   def titleInstanceResolverService
   def coverageExtenderService
 
@@ -112,58 +118,68 @@ public class PackageIngestService {
   
               Platform platform = Platform.resolve(platform_url_to_use, pc.platformName);
               // log.debug("Platform: ${platform}");
-  
-              // See if we already have a title platform record for the presence of this title on this platform
-              PlatformTitleInstance pti = PlatformTitleInstance.findByTitleInstanceAndPlatform(title, platform)
-  
-              if ( pti == null ) 
-                pti = new PlatformTitleInstance(titleInstance:title, 
-                                                platform:platform,
-                                                url:pc.url).save(flush:true, failOnError:true);
-  
-  
-              // Lookup or create a package content item record for this title on this platform in this package
-              // We only check for currently live pci records, as titles can come and go from the package.
-              // N.B. addedTimestamp removedTimestamp lastSeenTimestamp
-              def pci_qr = PackageContentItem.executeQuery('select pci from PackageContentItem as pci where pci.pti = :pti and pci.pkg.id = :pkg and pci.removedTimestamp is null',
-                                                           [pti:pti, pkg:result.packageId]);
-              PackageContentItem pci = pci_qr.size() == 1 ? pci_qr.get(0) : null; 
-  
-              if ( pci == null ) {
-                log.debug("[${result.titleCount}] Create new package content item");
-                pci = new PackageContentItem(
-                                             pti:pti, 
-                                             pkg:Pkg.get(result.packageId), 
-                                             note:pc.coverageNote, 
-                                             depth:pc.coverageDepth,
-                                             accessStart:null,
-                                             accessEnd:null, 
-                                             addedTimestamp:result.updateTime,
-                                             lastSeenTimestamp:result.updateTime).save(flush:true, failOnError:true);
+
+              if ( platform == null && PROXY_MISSING_PLATFORM ) {
+                platform = Platform.resolve('http://localhost.localdomain', 'This platform entry is used for error cases');
+              }
+
+              if ( platform != null ) {
+    
+                // See if we already have a title platform record for the presence of this title on this platform
+                PlatformTitleInstance pti = PlatformTitleInstance.findByTitleInstanceAndPlatform(title, platform)
+    
+                if ( pti == null ) 
+                  pti = new PlatformTitleInstance(titleInstance:title, 
+                                                  platform:platform,
+                                                  url:pc.url).save(flush:true, failOnError:true);
+    
+    
+                // Lookup or create a package content item record for this title on this platform in this package
+                // We only check for currently live pci records, as titles can come and go from the package.
+                // N.B. addedTimestamp removedTimestamp lastSeenTimestamp
+                def pci_qr = PackageContentItem.executeQuery('select pci from PackageContentItem as pci where pci.pti = :pti and pci.pkg.id = :pkg and pci.removedTimestamp is null',
+                                                             [pti:pti, pkg:result.packageId]);
+                PackageContentItem pci = pci_qr.size() == 1 ? pci_qr.get(0) : null; 
+    
+                if ( pci == null ) {
+                  log.debug("[${result.titleCount}] Create new package content item");
+                  pci = new PackageContentItem(
+                                               pti:pti, 
+                                               pkg:Pkg.get(result.packageId), 
+                                               note:pc.coverageNote, 
+                                               depth:pc.coverageDepth,
+                                               accessStart:null,
+                                               accessEnd:null, 
+                                               addedTimestamp:result.updateTime,
+                                               lastSeenTimestamp:result.updateTime).save(flush:true, failOnError:true);
+                }
+                else {
+                  // Note that we have seen the package content item now - so we don't delete it at the end.
+                  log.debug("[${result.titleCount}] update package content item (${pci.id}) set last seen to ${result.updateTime}");
+                  pci.lastSeenTimestamp = result.updateTime;
+                  // TODO: Check for and record any CHANGES to this title in this package (coverage, embargo, etc)
+                }
+    
+                // If the row has a coverage statement, check that the range of coverage we know about for this title on this platform
+                // extends to include the supplied information. It is a contract with the KB that we assume this is correct info.
+                // We store this generally for the title on the platform, and specifically for this title in this package on this platform.
+                if ( pc.coverage ) {
+    
+                  // We define coverage to be a list in the exchange format, but sometimes it comes just as a JSON map. Convert that
+                  // to the list of mpas that coverageExtenderService.extend expects
+                  List cov = pc.coverage instanceof List ? pc.coverage : [ pc.coverage ]
+    
+                  coverageExtenderService.extend(pti, cov, 'pti');
+                  coverageExtenderService.extend(pci, cov, 'pci');
+                  coverageExtenderService.extend(title, cov, 'ti');
+                }
+    
+                // Save needed either way
+                pci.save(flush:true, failOnError:true);
               }
               else {
-                // Note that we have seen the package content item now - so we don't delete it at the end.
-                log.debug("[${result.titleCount}] update package content item (${pci.id}) set last seen to ${result.updateTime}");
-                pci.lastSeenTimestamp = result.updateTime;
-                // TODO: Check for and record any CHANGES to this title in this package (coverage, embargo, etc)
+                log.error("[${result.titleCount}] unable to identify platform for package content item :: ${platform_url_to_use}, ${pc.platformName}");
               }
-  
-              // If the row has a coverage statement, check that the range of coverage we know about for this title on this platform
-              // extends to include the supplied information. It is a contract with the KB that we assume this is correct info.
-              // We store this generally for the title on the platform, and specifically for this title in this package on this platform.
-              if ( pc.coverage ) {
-  
-                // We define coverage to be a list in the exchange format, but sometimes it comes just as a JSON map. Convert that
-                // to the list of mpas that coverageExtenderService.extend expects
-                List cov = pc.coverage instanceof List ? pc.coverage : [ pc.coverage ]
-  
-                coverageExtenderService.extend(pti, cov, 'pti');
-                coverageExtenderService.extend(pci, cov, 'pci');
-                coverageExtenderService.extend(title, cov, 'ti');
-              }
-  
-              // Save needed either way
-              pci.save(flush:true, failOnError:true);
             }
             catch ( Exception e ) {
               log.error("[${result.titleCount}] problem",e);

--- a/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
+++ b/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
@@ -73,7 +73,9 @@ public class GOKbOAIAdapter implements KBCacheUpdater {
         response.success = { resp, xml ->
           // println "Success! ${resp.status} ${xml}"
           Map page_result = processPage(cursor, xml, source_name, cache)
-          println("processPage returned, processed ${page_result.count} packages");
+
+          println("processPage returned, processed ${page_result.count} packages, cursor will be ${page_result.new_cursor}");
+          // Store the cursor so we know where we are up to
           cache.updateCursor(source_name,page_result.new_cursor);
 
           if ( page_result.count > 0 ) {

--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -10,7 +10,7 @@
           "methods": ["GET", "POST"],
           "pathPattern": "/erm/sas"
         },{
-          "methods": ["GET", "PUT", "DELETE"],
+          "methods": ["GET", "PUT", "DELETE", "POST"],
           "pathPattern": "/erm/sas/{id}"
         },{
           "methods": ["GET"],


### PR DESCRIPTION
In preparation for eholdings intergation, make entitlements able to represent packages defined in external systems as well as the internal KB domain model. Added a script that demonstrates the kind of conversation that might take place between eholdings and agreements when creating agreements, and adding entitlements that refer to packages in EKB.