### PR TITLE
Fix/template references

### DIFF
--- a/service/grails-app/views/resource/_resourceList.gson
+++ b/service/grails-app/views/resource/_resourceList.gson
@@ -14,7 +14,7 @@ final Map theData = binding.variables
 // If we have exactly 1 parameter we assume that it is a collection as per a regular restful 'get' for a collection.  
 if (theData.size() == 1) {
   
-  json g.render(template:"../ermResource/ermResource", collection: theData.values()[0], var:'ermResource')
+  json g.render(template:"/ermResource/ermResource", collection: theData.values()[0], var:'ermResource')
   
 } else {
   
@@ -26,7 +26,7 @@ if (theData.size() == 1) {
     meta theData.meta
     totalRecords theData.totalRecords
     total theData.total
-    results g.render(template:"../ermResource/ermResource", collection: theData.results, var:'ermResource')
+    results g.render(template:"/ermResource/ermResource", collection: theData.results, var:'ermResource')
   }
   
 }

--- a/service/grails-app/views/subscriptionAgreement/resources.gson
+++ b/service/grails-app/views/subscriptionAgreement/resources.gson
@@ -1,1 +1,1 @@
-json g.render (template: '../resource/resourceList', model: (binding.variables))
+json g.render (template: '/resource/resourceList', model: (binding.variables))


### PR DESCRIPTION
Using relative `../` locations for templates breaks once it's packaged up in a war/jar. Just use absolute reference of `/` which resolves to the `grails-app/views` folder.