### PR TITLE
FOLIO-2235 Fix misplaced launchDescriptor Memory setting

### DIFF
--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -426,8 +426,12 @@
   "launchDescriptor": {
     "dockerImage": "${info.app.name}:${info.app.version}",
     "dockerArgs": {
-      "Memory": 872415232,
-      "HostConfig": { "PortBindings": { "8080/tcp":  [{ "HostPort": "%p" }] } }
+      "HostConfig": {
+        "Memory": 872415232,
+        "PortBindings": { 
+          "8080/tcp":  [{ "HostPort": "%p" }] 
+        }
+      }
     },
     "dockerPull" : false,
     "env": [


### PR DESCRIPTION
The "Memory" property belongs inside the "HostConfig" object.
See documentation linked from [FOLIO-2235](https://issues.folio.org/browse/FOLIO-2235).
Compare with other back-end modules.