### PR TITLE
ERM-700, ERM-702 and ERM-737: Changes to allow LAS:eR import

### DIFF
--- a/service/gradle.properties
+++ b/service/gradle.properties
@@ -1,7 +1,7 @@
 appName=mod-agreements
 grailsVersion=3.3.11
 grailsWrapperVersion=1.0.0
-appVersion=2.1.0
+appVersion=2.2.0
 gormVersion=6.1.12.RELEASE
 gradleWrapperVersion=3.5
 dockerTagSuffix=

--- a/service/grails-app/controllers/org/olf/PackageController.groovy
+++ b/service/grails-app/controllers/org/olf/PackageController.groovy
@@ -31,7 +31,8 @@ class PackageController extends OkapiTenantAwareController<Pkg> {
     final bindObj = this.getObjectToBind()
     log.debug("bindObj: ${bindObj}")
     importService.importPackageUsingErmSchema(bindObj as Map)
-    return render (status: 200)
+    Pkg pkg = Pkg.findByName(bindObj?.records[0]?.name)
+    return pkg?.id (status: 200)
   }
   
   def 'tsvParse' () {

--- a/service/grails-app/controllers/org/olf/PackageController.groovy
+++ b/service/grails-app/controllers/org/olf/PackageController.groovy
@@ -30,9 +30,21 @@ class PackageController extends OkapiTenantAwareController<Pkg> {
   def 'import' () {
     final bindObj = this.getObjectToBind()
     log.debug("bindObj: ${bindObj}")
+    Map bindObjMap = bindObj as Map
+    bindObjMap?.records[0]?.name = bindObjMap?.records[0]?.replace("\0", "");
+
+    log.debug("bindObj name: ${bindObj?.records[0]?.name}")
+    log.debug("bindObjMap name: ${bindObjMap?.records[0]?.name}")
     importService.importPackageUsingErmSchema(bindObj as Map)
+    log.debug("bindObj name: ${bindObj?.records[0]?.name}")
+    log.debug("bindObjMap name: ${bindObjMap?.records[0]?.name}")
+
+    log.debug("attempting to find package in ERM")
     Pkg pkg = Pkg.findByName(bindObj?.records[0]?.name)
-    return pkg?.id (status: 200)
+    log.debug("Package found?: ${pkg}")
+    log.debug("Package records?: ${pkg?.records}")
+    log.debug("Is package id a thing? : ${pkg?.id}")
+    return pkg?.id
   }
   
   def 'tsvParse' () {

--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -62,7 +62,7 @@ class PackageIngestService {
       removedTitles: 0,
       updatedTitles: 0,
       updatedAccessStart: 0,
-      updatedAccessEnd: 0
+      updatedAccessEnd: 0,
     ]
 
     Pkg pkg = null

--- a/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
+++ b/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
@@ -151,7 +151,7 @@ class TitleInstanceResolverService implements DataBinder{
     // a title if we know that it is a sibling of a print identifier.
     int num_class_one_identifiers_for_sibling = countClassOneIDs(citation.siblingInstanceIdentifiers)
 
-    List<IdentifierSchema> issn_or_isbn_ids = citation.siblingInstanceIdentifiers.findAll { it.namespace.toLowerCase() == 'issn' || it.namespace.toLowerCase() == 'isbn' }
+    Collection<IdentifierSchema> issn_or_isbn_ids = citation.siblingInstanceIdentifiers.findAll { it.namespace.toLowerCase() == 'issn' || it.namespace.toLowerCase() == 'isbn' }
     log.debug("Found list of sibling identifiers: ${issn_or_isbn_ids}")
 
 

--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -294,8 +294,12 @@
           "methods": ["DELETE"],
           "pathPattern": "/erm/custprops/{id}",
           "permissionsRequired": [ "erm.custprops.item.delete" ]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/erm/packages/import",
+          "permissionsRequired": [ "erm.packages.collection.import" ]
         }
-        
       ]
     },{
       "id" : "_tenant",
@@ -483,6 +487,8 @@
       "erm.custprops.edit",
       "erm.custprops.item.delete"
     ]
+  }, {
+    "permissionName": "erm.packages.collection.import"
   }],
   "launchDescriptor": {
     "dockerImage": "${info.app.name}:${info.app.version}",


### PR DESCRIPTION
Small tweaks to mod-agreements including:
- Changes to import services to pass package ids through to the import endpoint
- package  import endpoint now returns package id
- package import endpoint now exposed
