### PR TITLE
ERM-769: Fix to import of KBART files

### DIFF
--- a/service/grails-app/controllers/org/olf/PackageController.groovy
+++ b/service/grails-app/controllers/org/olf/PackageController.groovy
@@ -13,6 +13,9 @@ import java.time.LocalDate
 import org.springframework.web.multipart.MultipartFile
 import org.apache.commons.io.input.BOMInputStream
 
+import com.opencsv.ICSVParser
+import com.opencsv.CSVParser
+import com.opencsv.CSVParserBuilder
 import com.opencsv.CSVReader
 import com.opencsv.CSVReaderBuilder
 
@@ -64,7 +67,12 @@ class PackageController extends OkapiTenantAwareController<Pkg> {
     
     BOMInputStream bis = new BOMInputStream(file.getInputStream());
     Reader fr = new InputStreamReader(bis);
-    CSVReader csvReader = new CSVReaderBuilder(fr).build();
+    CSVParser parser = new CSVParserBuilder().withSeparator('\t' as char)
+        .withQuoteChar(ICSVParser.DEFAULT_QUOTE_CHARACTER)
+        .withEscapeChar(ICSVParser.DEFAULT_ESCAPE_CHARACTER)
+      .build();
+
+    CSVReader csvReader = new CSVReaderBuilder(fr).withCSVParser(parser).build();
 
     def completed = importService.importPackageFromKbart(csvReader, packageInfo)
 

--- a/service/grails-app/controllers/org/olf/PackageController.groovy
+++ b/service/grails-app/controllers/org/olf/PackageController.groovy
@@ -81,8 +81,7 @@ class PackageController extends OkapiTenantAwareController<Pkg> {
     } else {
       log.debug("KBART import failed")
     }
-    return render (status: 200)
-    render [:] as JSON;
+    return render ([:] as JSON)
   }
 
   def content () {

--- a/service/grails-app/domain/org/olf/general/jobs/KbartImportJob.groovy
+++ b/service/grails-app/domain/org/olf/general/jobs/KbartImportJob.groovy
@@ -5,6 +5,9 @@ import grails.gorm.MultiTenant
 import org.springframework.web.multipart.MultipartFile
 import org.apache.commons.io.input.BOMInputStream
 
+import com.opencsv.ICSVParser
+import com.opencsv.CSVParser
+import com.opencsv.CSVParserBuilder
 import com.opencsv.CSVReader
 import com.opencsv.CSVReaderBuilder
 
@@ -45,7 +48,12 @@ class KbartImportJob extends PersistentJob implements MultiTenant<KbartImportJob
         if (job.fileUpload && packageInfoValid) {
           BOMInputStream bis = new BOMInputStream(job.fileUpload.fileObject.fileContents.binaryStream);
           Reader fr = new InputStreamReader(bis);
-          CSVReader csvReader = new CSVReaderBuilder(fr).build();
+          CSVParser parser = new CSVParserBuilder().withSeparator('\t' as char)
+            .withQuoteChar(ICSVParser.DEFAULT_QUOTE_CHARACTER)
+            .withEscapeChar(ICSVParser.DEFAULT_ESCAPE_CHARACTER)
+          .build();
+
+          CSVReader csvReader = new CSVReaderBuilder(fr).withCSVParser(parser).build();
           importService.importPackageFromKbart(csvReader, packageInfo)
         } else {
           log.error "No file attached to the Job."

--- a/service/grails-app/services/org/olf/ImportService.groovy
+++ b/service/grails-app/services/org/olf/ImportService.groovy
@@ -298,7 +298,6 @@ class ImportService implements DataBinder {
     }
 
     if (pkg.packageContents.size() > 0) {
-      log.debug("PACKAGE CONTENTS: ${pkg.packageContents}")
       def result = packageIngestService.upsertPackage(pkg)
       //TODO Use this information to return true if the package imported successfully or false otherwise
       packageImported = true
@@ -312,7 +311,9 @@ class ImportService implements DataBinder {
   private String getFieldFromLine(String[] lineAsArray, Map acceptedFields, String fieldName) {
     //ToDo potentially work out how to make this slightly less icky, it worked a lot nicer without @CompileStatic
     String index = getIndexFromFieldName(acceptedFields, fieldName)
-    if (lineAsArray[index.toInteger()] == '') {
+    // Remember to discount any instances where the default '-1' still exists, don't want to grab the last index by mistake,
+    // We also don't want to return an empty string, we'd rather null
+    if (index.toInteger() == -1 || lineAsArray[index.toInteger()] == '') {
       return null;
     }
   return lineAsArray[index.toInteger()];
@@ -336,7 +337,9 @@ class ImportService implements DataBinder {
   private LocalDate parseDate(String date) {
     // We know that data coming in here matches yyyy, yyyy-mm or yyyy-mm-dd
     log.debug("Attempting to parse date: ${date}")
-    if (!date?.trim()) return null;
+    if (!date?.trim()) {
+      return null;
+    }
 
     LocalDate outputDate
 
@@ -368,9 +371,9 @@ class ImportService implements DataBinder {
   private List buildKBARTCoverage(String[] lineAsArray, Map acceptedFields) {
     String startDate = getFieldFromLine(lineAsArray, acceptedFields, 'CoverageStatement.startDate')
     String endDate = getFieldFromLine(lineAsArray, acceptedFields, 'CoverageStatement.endDate')
-
-    LocalDate endDateLocalDate = parseDate(startDate)
-    LocalDate startDateLocalDate = parseDate(endDate)
+    
+    LocalDate startDateLocalDate = parseDate(startDate)
+    LocalDate endDateLocalDate = parseDate(endDate)
     
     String instanceMedia = getFieldFromLine(lineAsArray, acceptedFields, 'instanceMedia').toLowerCase()
 

--- a/service/grails-app/services/org/olf/ImportService.groovy
+++ b/service/grails-app/services/org/olf/ImportService.groovy
@@ -247,32 +247,10 @@ class ImportService implements DataBinder {
       siblingInstanceIdentifier.value = getFieldFromLine(lineAsArray, acceptedFields, 'siblingInstanceIdentifiers')
       instanceIdentifier.value = getFieldFromLine(lineAsArray, acceptedFields, 'instanceIdentifiers')
 
-
       // Check that these aren't invalid identifiers, if they are, return an empty list
-      siblingInstanceIdentifier.validate();
-      instanceIdentifier.validate();
-
-      List instanceIdentifiers
-      if (!instanceIdentifier.hasErrors()) {
-        instanceIdentifiers = [instanceIdentifier]
-      } else {
-        instanceIdentifier.errors.allErrors.each { ObjectError error ->
-          log.error "${ messageSource.getMessage(error, LocaleContextHolder.locale) }"
-        }
-        instanceIdentifiers = []
-      }
-
-      List siblingInstanceIdentifiers
-      if (!siblingInstanceIdentifier.hasErrors()) {
-        siblingInstanceIdentifiers = [siblingInstanceIdentifier]
-      } else {
-        siblingInstanceIdentifier.errors.allErrors.each { ObjectError error ->
-          log.error "${ messageSource.getMessage(error, LocaleContextHolder.locale) }"
-        }
-        siblingInstanceIdentifiers = []
-      }
-
-
+      List instanceIdentifiers = identifierValidator(instanceIdentifier)
+      List siblingInstanceIdentifiers = identifierValidator(siblingInstanceIdentifier)
+      
       PackageContentImpl pkgLine = new PackageContentImpl(
         title: getFieldFromLine(lineAsArray, acceptedFields, 'title'),
         siblingInstanceIdentifiers: siblingInstanceIdentifiers,
@@ -395,6 +373,20 @@ class ImportService implements DataBinder {
       }
       return [];
     }
-    
+  }
+
+  private List identifierValidator(Identifier identifier) {
+    identifier.validate();
+
+    List identifiers
+    if (!identifier.hasErrors()) {
+      identifiers = [identifier]
+    } else {
+      identifier.errors.allErrors.each { ObjectError error ->
+        log.error "${ messageSource.getMessage(error, LocaleContextHolder.locale) }"
+      }
+      identifiers = []
+    }
+    return identifiers;
   }
 }

--- a/service/grails-app/services/org/olf/ImportService.groovy
+++ b/service/grails-app/services/org/olf/ImportService.groovy
@@ -312,8 +312,8 @@ class ImportService implements DataBinder {
     //ToDo potentially work out how to make this slightly less icky, it worked a lot nicer without @CompileStatic
     String index = getIndexFromFieldName(acceptedFields, fieldName)
     // Remember to discount any instances where the default '-1' still exists, don't want to grab the last index by mistake,
-    // We also don't want to return an empty string, we'd rather null
-    if (index.toInteger() == -1 || lineAsArray[index.toInteger()] == '') {
+    // We also don't want to return an empty string or whitespace, we'd rather null
+    if (index.toInteger() == -1 || lineAsArray[index.toInteger()].trim() == '') {
       return null;
     }
   return lineAsArray[index.toInteger()];
@@ -336,7 +336,6 @@ class ImportService implements DataBinder {
 
   private LocalDate parseDate(String date) {
     // We know that data coming in here matches yyyy, yyyy-mm or yyyy-mm-dd
-    log.debug("Attempting to parse date: ${date}")
     if (!date?.trim()) {
       return null;
     }

--- a/service/grails-app/services/org/olf/ImportService.groovy
+++ b/service/grails-app/services/org/olf/ImportService.groovy
@@ -7,6 +7,7 @@ import groovy.util.logging.Slf4j
 import org.olf.dataimport.erm.ErmPackageImpl
 import org.olf.dataimport.internal.InternalPackageImpl
 import org.olf.dataimport.internal.PackageContentImpl
+import org.olf.dataimport.internal.HeaderImpl
 import org.olf.dataimport.internal.PackageSchema
 import org.olf.dataimport.erm.PackageProvider
 import org.olf.dataimport.erm.Identifier
@@ -209,12 +210,12 @@ class ImportService implements DataBinder {
     final PackageProvider pkgPrv = new PackageProvider()
     pkgPrv.name = packageProvider
 
-    pkg.header = [
+    pkg.header = new HeaderImpl(
       packageName: packageName,
       packageSource: packageSource,
       packageSlug: packageReference,
       packageProvider: pkgPrv
-    ]
+    )
 
     String[] record;
     while ((record = file.readNext()) != null) {


### PR DESCRIPTION
- Switched csvReader usage to take into account tabs as separator, ignore quotes when used
- Cleanup of endpoint render method
- Changed coverage and identifier building methods, now they're validated before deciding whether or not to add them to the package resource
- Other miscellaneous cleanup