### PR TITLE
ERM-793, ERM-794, ERM-795: Allowing for setting of a "Trusted source for title instance metadata" tag

### DIFF
--- a/service/grails-app/controllers/org/olf/AdminController.groovy
+++ b/service/grails-app/controllers/org/olf/AdminController.groovy
@@ -42,8 +42,9 @@ class AdminController implements DataBinder{
         return
       }
       
-      // Else do the ingest.
-      result = packageIngestService.upsertPackage(package_data)
+      // Else do the ingest. (TRUE because this is a LOCAL import)
+      // TODO make this rely on JSON trusted tag
+      result = packageIngestService.upsertPackage(package_data, true)
     }
     else {
       log.warn("No file")

--- a/service/grails-app/controllers/org/olf/AdminController.groovy
+++ b/service/grails-app/controllers/org/olf/AdminController.groovy
@@ -42,9 +42,7 @@ class AdminController implements DataBinder{
         return
       }
       
-      // Else do the ingest. (TRUE because this is a LOCAL import)
-      // TODO make this rely on JSON trusted tag
-      result = packageIngestService.upsertPackage(package_data, true)
+      result = packageIngestService.upsertPackage(package_data)
     }
     else {
       log.warn("No file")

--- a/service/grails-app/controllers/org/olf/PackageController.groovy
+++ b/service/grails-app/controllers/org/olf/PackageController.groovy
@@ -62,6 +62,7 @@ class PackageController extends OkapiTenantAwareController<Pkg> {
       packageName: request.getParameter("packageName"),
       packageSource: request.getParameter("packageSource"),
       packageReference: request.getParameter("packageReference"),
+      trustedSourceTI: request.getParameter("trustedSourceTI"),
       packageProvider: request.getParameter("packageProvider")
     ]
     

--- a/service/grails-app/domain/org/olf/general/jobs/KbartImportJob.groovy
+++ b/service/grails-app/domain/org/olf/general/jobs/KbartImportJob.groovy
@@ -17,6 +17,7 @@ class KbartImportJob extends PersistentJob implements MultiTenant<KbartImportJob
   String packageSource
   String packageReference
   String packageProvider
+  boolean trustedSourceTI
 
   final Closure getWork() {
     
@@ -75,7 +76,6 @@ class KbartImportJob extends PersistentJob implements MultiTenant<KbartImportJob
   static constraints = {
       fileUpload (nullable:false)
       packageProvider (nullable:true)
-
   }
 
   static mapping = {
@@ -84,5 +84,6 @@ class KbartImportJob extends PersistentJob implements MultiTenant<KbartImportJob
                packageSource column:'package_source'
             packageReference column:'package_reference'
             packageProvider column: 'package_provider'
+            trustedSourceTI column: 'trusted_source_ti'
   }
 }

--- a/service/grails-app/domain/org/olf/general/jobs/KbartImportJob.groovy
+++ b/service/grails-app/domain/org/olf/general/jobs/KbartImportJob.groovy
@@ -29,6 +29,7 @@ class KbartImportJob extends PersistentJob implements MultiTenant<KbartImportJob
         // in a future session and we need to reread the event in.
         final KbartImportJob job = KbartImportJob.read(eventId)
 
+        // TODO add trustedSourceTI to package header
         Map packageInfo = [
           packageName: job.packageName,
           packageSource: job.packageSource,

--- a/service/grails-app/domain/org/olf/general/jobs/KbartImportJob.groovy
+++ b/service/grails-app/domain/org/olf/general/jobs/KbartImportJob.groovy
@@ -29,12 +29,12 @@ class KbartImportJob extends PersistentJob implements MultiTenant<KbartImportJob
         // in a future session and we need to reread the event in.
         final KbartImportJob job = KbartImportJob.read(eventId)
 
-        // TODO add trustedSourceTI to package header
         Map packageInfo = [
           packageName: job.packageName,
           packageSource: job.packageSource,
           packageReference: job.packageReference,
-          packageProvider: job.packageProvider
+          packageProvider: job.packageProvider,
+          trustedSourceTI: job.trustedSourceTI
         ]
 
         boolean packageInfoValid = true

--- a/service/grails-app/domain/org/olf/kb/RemoteKB.groovy
+++ b/service/grails-app/domain/org/olf/kb/RemoteKB.groovy
@@ -97,7 +97,7 @@ public class RemoteKB implements MultiTenant<RemoteKB> {
   private static final Set<String> updateableWhenReadOnly = ['trustedSourceTI']
   def beforeUpdate() {
     def dissallowedProperties = (updateableWhenReadOnly + this.dirtyPropertyNames) - updateableWhenReadOnly.intersect( this.dirtyPropertyNames )
-    if (readOnly == true && dissallowedProperties) {
+    if (readonly == true && dissallowedProperties) {
       log.debug("Denying update to KB ${this.id} / ${this.name} because 'readonly' is set to 'true' and updates were attempted to ${dissallowedProperties}")
       return false
     }

--- a/service/grails-app/domain/org/olf/kb/RemoteKB.groovy
+++ b/service/grails-app/domain/org/olf/kb/RemoteKB.groovy
@@ -93,11 +93,137 @@ public class RemoteKB implements MultiTenant<RemoteKB> {
     return "RemoteKB ${name} - ${type}/${uri}/${cursor}".toString()
   }
 
-  def beforeUpdate() {
+  // We want SOME properties to be editable, some not to be, so we have custom setters to declare which we can and can't set
+  def setName( String name ) {
     if (this.readonly == true) {
-      log.debug("Denying to update KB ${this.id} / ${this.name} because 'readonly' is set to 'true'")
-      return false
+      log.debug("Denying update of name as 'readonly' is set to 'true'")
+      return
     }
+    this.name = name
+  }
+
+  def setType( String type ) {
+    if (this.readonly == true) {
+      log.debug("Denying update of type as 'readonly' is set to 'true'")
+      return
+    }
+    this.type = type
+  }
+
+  def setCursor( String cursor ) {
+    if (this.readonly == true) {
+      log.debug("Denying update of cursor as 'readonly' is set to 'true'")
+      return
+    }
+    this.cursor = cursor
+  }
+
+  def setUri( String uri ) {
+    if (this.readonly == true) {
+      log.debug("Denying update of uri as 'readonly' is set to 'true'")
+      return
+    }
+    this.uri = uri
+  }
+
+  def setListPrefix( String listPrefix ) {
+    if (this.readonly == true) {
+      log.debug("Denying update of listPrefix as 'readonly' is set to 'true'")
+      return
+    }
+    this.listPrefix = listPrefix
+  }
+
+  def setFullPrefix( String fullPrefix ) {
+    if (this.readonly == true) {
+      log.debug("Denying update of fullPrefix as 'readonly' is set to 'true'")
+      return
+    }
+    this.fullPrefix = fullPrefix
+  }
+
+  def setPrincipal( String principal ) {
+    if (this.readonly == true) {
+      log.debug("Denying update of principal as 'readonly' is set to 'true'")
+      return
+    }
+    this.principal = principal
+  }
+
+  def setCredentials( String credentials ) {
+    if (this.readonly == true) {
+      log.debug("Denying update of credentials as 'readonly' is set to 'true'")
+      return
+    }
+    this.credentials = credentials
+  }
+
+  def setSyncStatus( String syncStatus ) {
+    if (this.readonly == true) {
+      log.debug("Denying update of syncStatus as 'readonly' is set to 'true'")
+      return
+    }
+    this.syncStatus = syncStatus
+  }
+
+  def setLastCheck( Long lastCheck ) {
+    if (this.readonly == true) {
+      log.debug("Denying update of lastCheck as 'readonly' is set to 'true'")
+      return
+    }
+    this.lastCheck = lastCheck
+  }
+
+  def setRectype( Long rectype ) {
+    if (this.readonly == true) {
+      log.debug("Denying update of rectype as 'readonly' is set to 'true'")
+      return
+    }
+    this.rectype = rectype
+  }
+
+  def setReadonly( boolean readonly ) {
+    if (this.readonly == true) {
+      log.debug("Denying update of readonly as 'readonly' is set to 'true'")
+      return
+    }
+    this.readonly = readonly
+  }
+
+  def setTrustedSourceTI( boolean trustedSourceTI ) {
+    this.trustedSourceTI = trustedSourceTI
+  }
+
+  def setSupportsHarvesting( Boolean supportsHarvesting ) {
+    if (this.readonly == true) {
+      log.debug("Denying update of supportsHarvesting as 'readonly' is set to 'true'")
+      return
+    }
+    this.supportsHarvesting = supportsHarvesting
+  }
+
+  def setActive( Boolean active ) {
+    if (this.readonly == true) {
+      log.debug("Denying update of active as 'readonly' is set to 'true'")
+      return
+    }
+    this.active = active
+  }
+
+  def setActivationSupported( Boolean activationSupported ) {
+    if (this.readonly == true) {
+      log.debug("Denying update of activationSupported as 'readonly' is set to 'true'")
+      return
+    }
+    this.activationSupported = activationSupported
+  }
+
+  def setActivationEnabled( Boolean activationEnabled ) {
+    if (this.readonly == true) {
+      log.debug("Denying update of activationEnabled as 'readonly' is set to 'true'")
+      return
+    }
+    this.activationEnabled = activationEnabled
   }
 
   def beforeDelete() {

--- a/service/grails-app/domain/org/olf/kb/RemoteKB.groovy
+++ b/service/grails-app/domain/org/olf/kb/RemoteKB.groovy
@@ -93,137 +93,14 @@ public class RemoteKB implements MultiTenant<RemoteKB> {
     return "RemoteKB ${name} - ${type}/${uri}/${cursor}".toString()
   }
 
-  // We want SOME properties to be editable, some not to be, so we have custom setters to declare which we can and can't set
-  def setName( String name ) {
-    if (this.readonly == true) {
-      log.debug("Denying update of name as 'readonly' is set to 'true'")
-      return
+  // When RemoteKB is readonly we want SOME properties to be editable, some not to be
+  private static final Set<String> updateableWhenReadOnly = ['trustedSourceTI']
+  def beforeUpdate() {
+    def dissallowedProperties = (updateableWhenReadOnly + this.dirtyPropertyNames) - updateableWhenReadOnly.intersect( this.dirtyPropertyNames )
+    if (readOnly == true && dissallowedProperties) {
+      log.debug("Denying update to KB ${this.id} / ${this.name} because 'readonly' is set to 'true' and updates were attempted to ${dissallowedProperties}")
+      return false
     }
-    this.name = name
-  }
-
-  def setType( String type ) {
-    if (this.readonly == true) {
-      log.debug("Denying update of type as 'readonly' is set to 'true'")
-      return
-    }
-    this.type = type
-  }
-
-  def setCursor( String cursor ) {
-    if (this.readonly == true) {
-      log.debug("Denying update of cursor as 'readonly' is set to 'true'")
-      return
-    }
-    this.cursor = cursor
-  }
-
-  def setUri( String uri ) {
-    if (this.readonly == true) {
-      log.debug("Denying update of uri as 'readonly' is set to 'true'")
-      return
-    }
-    this.uri = uri
-  }
-
-  def setListPrefix( String listPrefix ) {
-    if (this.readonly == true) {
-      log.debug("Denying update of listPrefix as 'readonly' is set to 'true'")
-      return
-    }
-    this.listPrefix = listPrefix
-  }
-
-  def setFullPrefix( String fullPrefix ) {
-    if (this.readonly == true) {
-      log.debug("Denying update of fullPrefix as 'readonly' is set to 'true'")
-      return
-    }
-    this.fullPrefix = fullPrefix
-  }
-
-  def setPrincipal( String principal ) {
-    if (this.readonly == true) {
-      log.debug("Denying update of principal as 'readonly' is set to 'true'")
-      return
-    }
-    this.principal = principal
-  }
-
-  def setCredentials( String credentials ) {
-    if (this.readonly == true) {
-      log.debug("Denying update of credentials as 'readonly' is set to 'true'")
-      return
-    }
-    this.credentials = credentials
-  }
-
-  def setSyncStatus( String syncStatus ) {
-    if (this.readonly == true) {
-      log.debug("Denying update of syncStatus as 'readonly' is set to 'true'")
-      return
-    }
-    this.syncStatus = syncStatus
-  }
-
-  def setLastCheck( Long lastCheck ) {
-    if (this.readonly == true) {
-      log.debug("Denying update of lastCheck as 'readonly' is set to 'true'")
-      return
-    }
-    this.lastCheck = lastCheck
-  }
-
-  def setRectype( Long rectype ) {
-    if (this.readonly == true) {
-      log.debug("Denying update of rectype as 'readonly' is set to 'true'")
-      return
-    }
-    this.rectype = rectype
-  }
-
-  def setReadonly( boolean readonly ) {
-    if (this.readonly == true) {
-      log.debug("Denying update of readonly as 'readonly' is set to 'true'")
-      return
-    }
-    this.readonly = readonly
-  }
-
-  def setTrustedSourceTI( boolean trustedSourceTI ) {
-    this.trustedSourceTI = trustedSourceTI
-  }
-
-  def setSupportsHarvesting( Boolean supportsHarvesting ) {
-    if (this.readonly == true) {
-      log.debug("Denying update of supportsHarvesting as 'readonly' is set to 'true'")
-      return
-    }
-    this.supportsHarvesting = supportsHarvesting
-  }
-
-  def setActive( Boolean active ) {
-    if (this.readonly == true) {
-      log.debug("Denying update of active as 'readonly' is set to 'true'")
-      return
-    }
-    this.active = active
-  }
-
-  def setActivationSupported( Boolean activationSupported ) {
-    if (this.readonly == true) {
-      log.debug("Denying update of activationSupported as 'readonly' is set to 'true'")
-      return
-    }
-    this.activationSupported = activationSupported
-  }
-
-  def setActivationEnabled( Boolean activationEnabled ) {
-    if (this.readonly == true) {
-      log.debug("Denying update of activationEnabled as 'readonly' is set to 'true'")
-      return
-    }
-    this.activationEnabled = activationEnabled
   }
 
   def beforeDelete() {

--- a/service/grails-app/domain/org/olf/kb/RemoteKB.groovy
+++ b/service/grails-app/domain/org/olf/kb/RemoteKB.groovy
@@ -33,6 +33,8 @@ public class RemoteKB implements MultiTenant<RemoteKB> {
 
   // Mark KB as protected/readonly, e.g. the LOCAL KB
   boolean readonly = false
+  // Mark KB as a trusted source of title instance metadata
+  boolean trustedSourceTI = false
   // Harvesting role
   /** Does this remote KB support harvesting */
   Boolean supportsHarvesting
@@ -64,6 +66,7 @@ public class RemoteKB implements MultiTenant<RemoteKB> {
              syncStatus column:'rkb_sync_status'
               lastCheck column:'rkb_last_check'
                readonly column:'rkb_readonly'
+        trustedSourceTI column:'rkb_trusted_source_ti'
   }
 
   static constraints = {
@@ -82,6 +85,7 @@ public class RemoteKB implements MultiTenant<RemoteKB> {
              syncStatus(nullable:true, blank:false)
               lastCheck(nullable:true, blank:false)
                readonly(nullable:true, blank:false, bindable:false)
+        trustedSourceTI(nullable: false, blank: false)
   }
 
 

--- a/service/grails-app/migrations/update-mod-agreements-2-3.groovy
+++ b/service/grails-app/migrations/update-mod-agreements-2-3.groovy
@@ -111,4 +111,9 @@ databaseChangeLog = {
     addNotNullConstraint(tableName: "remotekb", columnName: "rkb_trusted_source_ti", columnDataType: "boolean")
   }
 
+  changeSet(author: "efreestone (manual)", id: "202004081754-001") {
+    addColumn(tableName: "kbart_import_job") {
+      column(name: "trusted_source_ti", type: "boolean")
+    }
 }
+

--- a/service/grails-app/migrations/update-mod-agreements-2-3.groovy
+++ b/service/grails-app/migrations/update-mod-agreements-2-3.groovy
@@ -115,5 +115,6 @@ databaseChangeLog = {
     addColumn(tableName: "kbart_import_job") {
       column(name: "trusted_source_ti", type: "boolean")
     }
+  }
 }
 

--- a/service/grails-app/migrations/update-mod-agreements-2-3.groovy
+++ b/service/grails-app/migrations/update-mod-agreements-2-3.groovy
@@ -7,4 +7,30 @@ databaseChangeLog = {
         confirm: "Successfully updated the pd_description column."
       )
   }
+  changeSet(author: "efreestone (manual)", id: "202003250914-1") {
+    addColumn(tableName: "remotekb") {
+      column(name: "rkb_trusted_source_ti", type: "boolean")
+    }
+  }
+  // Set all remote KBs to not-trusted
+  changeSet(author: "efreestone (manual)", id: "202003250914-2") {
+    grailsChange {
+      change {
+        sql.execute("UPDATE ${database.defaultSchemaName}.remotekb SET rkb_trusted_source_ti=false".toString())
+      }
+    }
+  }
+  // Set LOCAL to trusted
+  changeSet(author: "efreestone (manual)", id: "202003250914-3") {
+    grailsChange {
+      change {
+        sql.execute("UPDATE ${database.defaultSchemaName}.remotekb SET rkb_trusted_source_ti=true WHERE rkb_name='LOCAL'".toString())
+      }
+    }
+  }
+  // Add non-nullable constraint
+  changeSet(author: "efreestone (manual)", id: "202003250914-4") {
+    addNotNullConstraint(tableName: "remotekb", columnName: "rkb_trusted_source_ti", columnDataType: "boolean".toString())
+  }
+
 }

--- a/service/grails-app/migrations/update-mod-agreements-2-3.groovy
+++ b/service/grails-app/migrations/update-mod-agreements-2-3.groovy
@@ -12,11 +12,11 @@ databaseChangeLog = {
       column(name: "rkb_trusted_source_ti", type: "boolean")
     }
   }
-  // Set all remote KBs to not-trusted
+  // Set all external remote KBs to not-trusted
   changeSet(author: "efreestone (manual)", id: "202003250914-2") {
     grailsChange {
       change {
-        sql.execute("UPDATE ${database.defaultSchemaName}.remotekb SET rkb_trusted_source_ti=false".toString())
+        sql.execute("UPDATE ${database.defaultSchemaName}.remotekb SET rkb_trusted_source_ti=FALSE WHERE rkb_name NOT LIKE 'LOCAL';".toString())
       }
     }
   }
@@ -24,13 +24,13 @@ databaseChangeLog = {
   changeSet(author: "efreestone (manual)", id: "202003250914-3") {
     grailsChange {
       change {
-        sql.execute("UPDATE ${database.defaultSchemaName}.remotekb SET rkb_trusted_source_ti=true WHERE rkb_name='LOCAL'".toString())
+        sql.execute("UPDATE ${database.defaultSchemaName}.remotekb SET rkb_trusted_source_ti=TRUE WHERE rkb_name LIKE 'LOCAL';".toString())
       }
     }
   }
   // Add non-nullable constraint
   changeSet(author: "efreestone (manual)", id: "202003250914-4") {
-    addNotNullConstraint(tableName: "remotekb", columnName: "rkb_trusted_source_ti", columnDataType: "boolean".toString())
+    addNotNullConstraint(tableName: "remotekb", columnName: "rkb_trusted_source_ti", columnDataType: "boolean")
   }
 
 }

--- a/service/grails-app/services/org/olf/ImportService.groovy
+++ b/service/grails-app/services/org/olf/ImportService.groovy
@@ -136,6 +136,7 @@ class ImportService implements DataBinder {
     String packageSource
     String packageReference
     String packageProvider
+    Boolean trustedSourceTI = packageInfo.trustedSourceTI
 
     if ( packageInfo.packageName == null ||
          packageInfo.packageSource == null ||
@@ -215,7 +216,8 @@ class ImportService implements DataBinder {
       packageName: packageName,
       packageSource: packageSource,
       packageSlug: packageReference,
-      packageProvider: pkgPrv
+      packageProvider: pkgPrv,
+      trustedSourceTI: trustedSourceTI
     )
 
     String[] record;

--- a/service/grails-app/services/org/olf/ImportService.groovy
+++ b/service/grails-app/services/org/olf/ImportService.groovy
@@ -105,7 +105,9 @@ class ImportService implements DataBinder {
       pkg.validate()
       if (!pkg.errors.hasErrors()) {
         // Ingest the package.
-        Map result = packageIngestService.upsertPackage(pkg)
+
+        //TODO this true should depend on whether or not the source is trusted in JSON file
+        Map result = packageIngestService.upsertPackage(pkg, true)
         String upsertPackagePackageId = result.packageId
         
         packageImported = true
@@ -281,8 +283,8 @@ class ImportService implements DataBinder {
     }
 
     if (pkg.packageContents.size() > 0) {
-      def result = packageIngestService.upsertPackage(pkg)
-      //TODO Use this information to return true if the package imported successfully or false otherwise
+      // TODO The true here should depend on whether the import can be trusted or not.
+      def result = packageIngestService.upsertPackage(pkg, true)
       packageImported = true
     } else {
       log.error("Package contents empty, skipping package creation")

--- a/service/grails-app/services/org/olf/ImportService.groovy
+++ b/service/grails-app/services/org/olf/ImportService.groovy
@@ -106,8 +106,7 @@ class ImportService implements DataBinder {
       if (!pkg.errors.hasErrors()) {
         // Ingest the package.
 
-        //TODO this true should depend on whether or not the source is trusted in JSON file
-        Map result = packageIngestService.upsertPackage(pkg, true)
+        Map result = packageIngestService.upsertPackage(pkg)
         String upsertPackagePackageId = result.packageId
         
         packageImported = true
@@ -283,8 +282,7 @@ class ImportService implements DataBinder {
     }
 
     if (pkg.packageContents.size() > 0) {
-      // TODO The true here should depend on whether the import can be trusted or not.
-      def result = packageIngestService.upsertPackage(pkg, true)
+      def result = packageIngestService.upsertPackage(pkg)
       packageImported = true
     } else {
       log.error("Package contents empty, skipping package creation")

--- a/service/grails-app/services/org/olf/KnowledgeBaseCacheService.groovy
+++ b/service/grails-app/services/org/olf/KnowledgeBaseCacheService.groovy
@@ -44,7 +44,7 @@ where ( exists ( select pci.id
       log.debug("Run remote kb sync:: ${rkb.id}/${rkb.name}/${rkb.uri}")
       Class cls = Class.forName(rkb.type)
       KBCacheUpdater cache_updater = cls.newInstance()
-      cache_updater.freshenPackageData(rkb.name, rkb.uri, rkb.cursor, this)
+      cache_updater.freshenPackageData(rkb.name, rkb.uri, rkb.cursor, this, rkb.trustedSourceTI)
     }
   }
 
@@ -74,12 +74,11 @@ where ( exists ( select pci.id
    *
    *  @return map containing information about the packageId of the newly loaded or existing updated package
    */
-  public Map onPackageChange(String rkb_name, PackageSchema package_data) {
+  public Map onPackageChange(String rkb_name, PackageSchema package_data, boolean trustedSourceTI) {
     Map result = null
     RemoteKB.withTransaction([propagationBehavior: TransactionDefinition.PROPAGATION_REQUIRES_NEW]) {
       log.debug("onPackageChange(${rkb_name},...)")
-      // TODO this will need to rely on the trusted status of the import -- as to whether it's true or not
-      result = packageIngestService.upsertPackage(package_data, rkb_name)
+      result = packageIngestService.upsertPackage(package_data, rkb_name, false, trustedSourceTI)
     }
     log.debug("onPackageChange(${rkb_name},...) returning ${result}")
 

--- a/service/grails-app/services/org/olf/KnowledgeBaseCacheService.groovy
+++ b/service/grails-app/services/org/olf/KnowledgeBaseCacheService.groovy
@@ -74,11 +74,11 @@ where ( exists ( select pci.id
    *
    *  @return map containing information about the packageId of the newly loaded or existing updated package
    */
-  public Map onPackageChange(String rkb_name, PackageSchema package_data, boolean trustedSourceTI = false) {
+  public Map onPackageChange(String rkb_name, PackageSchema package_data) {
     Map result = null
     RemoteKB.withTransaction([propagationBehavior: TransactionDefinition.PROPAGATION_REQUIRES_NEW]) {
       log.debug("onPackageChange(${rkb_name},...)")
-      result = packageIngestService.upsertPackage(package_data, rkb_name, false, trustedSourceTI)
+      result = packageIngestService.upsertPackage(package_data, rkb_name, false)
     }
     log.debug("onPackageChange(${rkb_name},...) returning ${result}")
 

--- a/service/grails-app/services/org/olf/KnowledgeBaseCacheService.groovy
+++ b/service/grails-app/services/org/olf/KnowledgeBaseCacheService.groovy
@@ -78,6 +78,7 @@ where ( exists ( select pci.id
     Map result = null
     RemoteKB.withTransaction([propagationBehavior: TransactionDefinition.PROPAGATION_REQUIRES_NEW]) {
       log.debug("onPackageChange(${rkb_name},...)")
+      // TODO this will need to rely on the trusted status of the import -- as to whether it's true or not
       result = packageIngestService.upsertPackage(package_data, rkb_name)
     }
     log.debug("onPackageChange(${rkb_name},...) returning ${result}")

--- a/service/grails-app/services/org/olf/KnowledgeBaseCacheService.groovy
+++ b/service/grails-app/services/org/olf/KnowledgeBaseCacheService.groovy
@@ -74,7 +74,7 @@ where ( exists ( select pci.id
    *
    *  @return map containing information about the packageId of the newly loaded or existing updated package
    */
-  public Map onPackageChange(String rkb_name, PackageSchema package_data, boolean trustedSourceTI) {
+  public Map onPackageChange(String rkb_name, PackageSchema package_data, boolean trustedSourceTI = false) {
     Map result = null
     RemoteKB.withTransaction([propagationBehavior: TransactionDefinition.PROPAGATION_REQUIRES_NEW]) {
       log.debug("onPackageChange(${rkb_name},...)")

--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -76,8 +76,7 @@ class PackageIngestService {
        kb = new RemoteKB( name:remotekbname,
                           rectype: new Long(1),
                           active: Boolean.TRUE,
-                          trustedSourceTI: Boolean.FALSE,
-                          readonly:readOnly
+                          readonly:readOnly,
                           trustedSourceTI:trustedSourceTI).save(flush:true, failOnError:true)
       }
 

--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -38,8 +38,8 @@ class PackageIngestService {
   // looking up an Org in vendors and stashing the vendor info in the local cache table.
   DependentModuleProxyService dependentModuleProxyService
 
-  public Map upsertPackage(PackageSchema package_data) {
-    return upsertPackage(package_data,'LOCAL',true)
+  public Map upsertPackage(PackageSchema package_data, boolean trustedSourceTI) {
+    return upsertPackage(package_data,'LOCAL',true, trustedSourceTI)
   }
 
   private static final def countChanges = ['accessStart', 'accessEnd']
@@ -53,7 +53,7 @@ class PackageIngestService {
    * package into the KB.
    * @return id of package upserted
    */
-  public Map upsertPackage(PackageSchema package_data, String remotekbname, boolean readOnly=false) {
+  public Map upsertPackage(PackageSchema package_data, String remotekbname, boolean readOnly=false, boolean trustedSourceTI = false) {
 
     def result = [
       startTime: System.currentTimeMillis(),
@@ -76,7 +76,9 @@ class PackageIngestService {
        kb = new RemoteKB( name:remotekbname,
                           rectype: new Long(1),
                           active: Boolean.TRUE,
-                          readonly:readOnly).save(flush:true, failOnError:true)
+                          trustedSourceTI: Boolean.FALSE,
+                          readonly:readOnly
+                          trustedSourceTI:trustedSourceTI).save(flush:true, failOnError:true)
       }
 
       result.updateTime = System.currentTimeMillis()

--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -39,8 +39,6 @@ class PackageIngestService {
   DependentModuleProxyService dependentModuleProxyService
 
   public Map upsertPackage(PackageSchema package_data) {
-    boolean trustedSourceTIValue = trustedSourceTI
-
     return upsertPackage(package_data,'LOCAL',true)
   }
 
@@ -68,6 +66,7 @@ class PackageIngestService {
     ]
 
     Pkg pkg = null
+    Boolean trustedSourceTI = package_data.header?.trustedSourceTI
     Pkg.withNewTransaction { status ->
       // ERM caches many remote KB sources in it's local package inventory
       // Look up which remote kb via the name
@@ -81,7 +80,6 @@ class PackageIngestService {
                           trustedSourceTI:false).save(flush:true, failOnError:true)
       }
 
-      Boolean trustedSourceTI = package_data.header?.trustedSourceTI
       if (trustedSourceTI == null) {
         // If we're not explicitly handed trusted information, default to whatever the remote KB setting is
         trustedSourceTI = kb.trustedSourceTI

--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -120,7 +120,7 @@ class PackageIngestService {
 
           // resolve may return null, used to throw exception which causes the whole package to be rejected. Needs
           // discussion to work out best way to handle.
-          TitleInstance title = titleInstanceResolverService.resolve(pc)
+          TitleInstance title = titleInstanceResolverService.resolve(pc, trustedSourceTI)
 
           if ( title != null ) {
 

--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -83,6 +83,11 @@ class PackageIngestService {
       if (trustedSourceTI == null) {
         // If we're not explicitly handed trusted information, default to whatever the remote KB setting is
         trustedSourceTI = kb.trustedSourceTI
+        if (trustedSourceTI == null) {
+          // If it somehow remains unset, default to false, but with warning
+          log.warn("Could not find trustedSourceTI setting for KB, defaulting to false")
+          trustedSourceTI = false
+        }
       }
 
       result.updateTime = System.currentTimeMillis()

--- a/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
+++ b/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
@@ -289,19 +289,39 @@ class TitleInstanceResolverService implements DataBinder{
    */ 
   private void checkForEnrichment(TitleInstance title, ContentItemSchema citation, boolean trustedSourceTI) {
     log.debug("Checking for enrichment of Title Instance: ${title} :: trusted: ${trustedSourceTI}")
-    if (trustedSourceTI != false) {
-      log.debug("We've got to this bit now")
-      log.debug("TITLE INSTANCE title: ${title.name}")
-      log.debug("TITLE INSTANCE firstAuthor: ${title.firstAuthor}")
-      log.debug("TITLE INSTANCE firstEditor: ${title.firstEditor}")
-      log.debug("TITLE INSTANCE monographEdition: ${title.monographEdition}")
-      log.debug("TITLE INSTANCE monographVolume: ${title.monographVolume}")
-      log.debug("CITATION title: ${citation.title}")
-      log.debug("CITATION dateMonographPublished: ${citation.dateMonographPublished}")
-      log.debug("CITATION firstAuthor: ${citation.firstAuthor}")
-      log.debug("CITATION firstEditor: ${citation.firstEditor}")
-      log.debug("CITATION monographEdition: ${citation.monographEdition}")
-      log.debug("CITATION monographVolume: ${citation.monographVolume}")
+    if (trustedSourceTI == true) {
+      log.debug("Trusted source for TI enrichment--enriching")
+
+      if (title.name != citation.title) {
+        title.name = citation.title
+      }
+
+      if (title.dateMonographPublished != citation.dateMonographPublished) {
+        title.dateMonographPublished = citation.dateMonographPublished
+      }
+
+      if (title.firstAuthor != citation.firstAuthor) {
+        title.firstAuthor = citation.firstAuthor
+      }
+      
+      if (title.firstAuthor != citation.firstAuthor) {
+        title.firstAuthor = citation.firstAuthor
+      }
+
+      if (title.firstEditor != citation.firstEditor) {
+        title.firstEditor = citation.firstEditor
+      }
+
+      if (title.monographEdition != citation.monographEdition) {
+        title.monographEdition = citation.monographEdition
+      }
+
+      if (title.monographVolume != citation.monographVolume) {
+        title.monographVolume = citation.monographVolume
+      }
+      title.save(flush: true)
+    } else {
+      log.debug("Not a trusted source for TI enrichment--skipping")
     }
     return null;
   }

--- a/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
+++ b/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
@@ -12,6 +12,9 @@ import org.olf.kb.Work
 import grails.gorm.transactions.Transactional
 import grails.web.databinding.DataBinder
 
+
+import groovy.json.*
+
 /**
  * This service works at the module level, it's often called without a tenant context.
  */
@@ -75,7 +78,7 @@ class TitleInstanceResolverService implements DataBinder{
    *     } ]
    *   }
    */
-  public TitleInstance resolve(ContentItemSchema citation) {
+  public TitleInstance resolve(ContentItemSchema citation, boolean trustedSourceTI) {
     // log.debug("TitleInstanceResolverService::resolve(${citation})");
     TitleInstance result = null;
 
@@ -116,7 +119,7 @@ class TitleInstanceResolverService implements DataBinder{
         case(1):
           log.debug("Exact match. Enrich title.")
           result = candidate_list.get(0)
-          checkForEnrichment(result, citation)
+          checkForEnrichment(result, citation, trustedSourceTI)
           break;
         default:
           log.warn("title matched ${num_matches} records with a threshold >= ${MATCH_THRESHOLD} . Unable to continue. Matching IDs: ${candidate_list.collect { it.id }}. class one identifier count: ${num_class_one_identifiers}");
@@ -284,8 +287,23 @@ class TitleInstanceResolverService implements DataBinder{
    * an identifier, we will need to add identifiers to that record when we see a record that
    * suggests identifiers for that title match.
    */ 
-  private void checkForEnrichment(TitleInstance title, ContentItemSchema citation) {
-    return
+  private void checkForEnrichment(TitleInstance title, ContentItemSchema citation, boolean trustedSourceTI) {
+    log.debug("Checking for enrichment of Title Instance: ${title} :: trusted: ${trustedSourceTI}")
+    if (trustedSourceTI != false) {
+      log.debug("We've got to this bit now")
+      log.debug("TITLE INSTANCE title: ${title.name}")
+      log.debug("TITLE INSTANCE firstAuthor: ${title.firstAuthor}")
+      log.debug("TITLE INSTANCE firstEditor: ${title.firstEditor}")
+      log.debug("TITLE INSTANCE monographEdition: ${title.monographEdition}")
+      log.debug("TITLE INSTANCE monographVolume: ${title.monographVolume}")
+      log.debug("CITATION title: ${citation.title}")
+      log.debug("CITATION dateMonographPublished: ${citation.dateMonographPublished}")
+      log.debug("CITATION firstAuthor: ${citation.firstAuthor}")
+      log.debug("CITATION firstEditor: ${citation.firstEditor}")
+      log.debug("CITATION monographEdition: ${citation.monographEdition}")
+      log.debug("CITATION monographVolume: ${citation.monographVolume}")
+    }
+    return null;
   }
 
   /**

--- a/service/src/main/groovy/org/olf/dataimport/erm/ErmPackageImpl.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/erm/ErmPackageImpl.groovy
@@ -15,6 +15,7 @@ class ErmPackageImpl implements PackageHeaderSchema, PackageSchema, Validateable
   String reference
   String name
   PackageProvider packageProvider
+  Boolean trustedSourceTI
   Set<ContentItem> contentItems = []
   
   // Defaults for internal scheam so we can make them optional in the constraints.
@@ -65,6 +66,12 @@ class ErmPackageImpl implements PackageHeaderSchema, PackageSchema, Validateable
   public Collection<ContentItem> getPackageContents() {
     contentItems
   }
+
+    @Override
+  public Boolean getTrustedSourceTI() {
+    trustedSourceTI
+  }
+  
   
   String toString() {
     "${name} from ${packageProvider}"

--- a/service/src/main/groovy/org/olf/dataimport/erm/ErmPackageImpl.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/erm/ErmPackageImpl.groovy
@@ -33,6 +33,7 @@ class ErmPackageImpl implements PackageHeaderSchema, PackageSchema, Validateable
     endDate nullable: true
     _intenalId nullable: true, blank: false
     status nullable: true, blank: false
+    trustedSourceTI nullable: true
     
     source    nullable: false, blank: false
     reference nullable: false, blank: false

--- a/service/src/main/groovy/org/olf/dataimport/internal/HeaderImpl.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/HeaderImpl.groovy
@@ -15,6 +15,7 @@ class HeaderImpl implements PackageHeaderSchema, Validateable {
   String packageSource
   String status
   String packageName
+  Boolean trustedSourceTI
   LocalDate startDate
   LocalDate endDate
   String packageSlug

--- a/service/src/main/groovy/org/olf/dataimport/internal/PackageSchema.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/PackageSchema.groovy
@@ -28,6 +28,7 @@ interface PackageSchema extends Validateable {
     "startDate": "2015-01-01T00:00:00Z",
     "endDate": "2020-12-31T00:00:00Z",
     "packageSlug": "kint_test_001",
+    "trustedSourceTI": true,
     "_intenalId": 276432871386
     */
     
@@ -39,6 +40,7 @@ interface PackageSchema extends Validateable {
     String getPackageSlug()
     String getStatus()
     String get_intenalId()
+    Boolean getTrustedSourceTI()
   }
   
   @CompileStatic

--- a/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
+++ b/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
@@ -127,12 +127,12 @@ public class GOKbOAIAdapter implements KBCacheUpdater, DataBinder {
 
       log.debug("Processing OAI record :: ${result.count} ${record_identifier} ${package_name}")
 
-      PackageSchema json_package_description = gokbToERM(record)
+      PackageSchema json_package_description = gokbToERM(record, trustedSourceTI)
       if ( json_package_description.header.status == 'deleted' ) {
         // ToDo: Decide what to do about deleted records
       }
       else {
-        cache.onPackageChange(source_name, json_package_description, trustedSourceTI)
+        cache.onPackageChange(source_name, json_package_description)
       }
 
       if ( datestamp > result.new_cursor ) {
@@ -158,7 +158,7 @@ public class GOKbOAIAdapter implements KBCacheUpdater, DataBinder {
    * the GOKb records look like this
    *   https://gokbt.gbv.de/gokb/oai/index/packages?verb=ListRecords&metadataPrefix=gokb
    */
-  private InternalPackageImpl gokbToERM(Object xml_gokb_record) {
+  private InternalPackageImpl gokbToERM(Object xml_gokb_record, boolean trustedSourceTI) {
 
     def package_record = xml_gokb_record?.metadata?.gokb?.package
 
@@ -182,6 +182,7 @@ public class GOKbOAIAdapter implements KBCacheUpdater, DataBinder {
           ],
           packageSource:'GOKb',
           packageName: package_name,
+          trustedSourceTI: trustedSourceTI,
           packageSlug: package_shortcode
         ],
         packageContents: []

--- a/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
+++ b/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
@@ -26,8 +26,8 @@ public class GOKbOAIAdapter implements KBCacheUpdater, DataBinder {
   public void freshenPackageData(String source_name,
                                  String base_url,
                                  String current_cursor,
-                                 KBCache cache
-                                 boolean trustedSourceTI) {
+                                 KBCache cache,
+                                 boolean trustedSourceTI = false) {
 
     log.debug("GOKbOAIAdapter::freshen - fetching from URI: ${base_url}")
     def jpf_api = new HTTPBuilder(base_url)

--- a/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
+++ b/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
@@ -26,7 +26,8 @@ public class GOKbOAIAdapter implements KBCacheUpdater, DataBinder {
   public void freshenPackageData(String source_name,
                                  String base_url,
                                  String current_cursor,
-                                 KBCache cache) {
+                                 KBCache cache
+                                 boolean trustedSourceTI) {
 
     log.debug("GOKbOAIAdapter::freshen - fetching from URI: ${base_url}")
     def jpf_api = new HTTPBuilder(base_url)
@@ -62,7 +63,7 @@ public class GOKbOAIAdapter implements KBCacheUpdater, DataBinder {
           // println "Success! ${resp.status} ${xml}"
           log.debug("got page of data from OAI, cursor=${cursor}, ...")
 
-          Map page_result = processPage(cursor, xml, source_name, cache)
+          Map page_result = processPage(cursor, xml, source_name, cache, trustedSourceTI)
 
 
           log.debug("processPage returned, processed ${page_result.count} packages, cursor will be ${page_result.new_cursor}")
@@ -102,7 +103,7 @@ public class GOKbOAIAdapter implements KBCacheUpdater, DataBinder {
   }
 
 
-  private Map processPage(String cursor, Object oai_page, String source_name, KBCache cache) {
+  private Map processPage(String cursor, Object oai_page, String source_name, KBCache cache, boolean trustedSourceTI) {
 
     final SimpleDateFormat sdf = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
 
@@ -131,7 +132,7 @@ public class GOKbOAIAdapter implements KBCacheUpdater, DataBinder {
         // ToDo: Decide what to do about deleted records
       }
       else {
-        cache.onPackageChange(source_name, json_package_description)
+        cache.onPackageChange(source_name, json_package_description, trustedSourceTI)
       }
 
       if ( datestamp > result.new_cursor ) {

--- a/service/src/main/okapi/tenant/sample_data/diku-data.groovy
+++ b/service/src/main/okapi/tenant/sample_data/diku-data.groovy
@@ -14,6 +14,7 @@ if (!local_kb ) {
   
   // Ensure we make this one read only.
   local_kb.readonly = true
+  local_kb.trustedSourceTI = true
   local_kb.save(flush:true, failOnError:true)
 }
 


### PR DESCRIPTION
This PR creates a `trustedSourceTI` tag on both `RemoteKB`s and `KbartJobs`, as well as extending the JSON schema to allow them to be set there.
- A trusted tag set to true on an import job means that that import will be allowed to overwrite selected title metadata, and visa versa for false.
- An import without this tag will defer to the LOCAL remoteKB object's setting (And if it cannot find this then `false`)
