### PR TITLE
ERM-839: Fixed bug preventing file imports

### DIFF
--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -111,7 +111,8 @@ class PackageIngestService {
       }
 
       if ( pkg == null ) {
-        if (package_data.header.status == 'Current' || package_data.header.status == 'Expected') {
+        final String statusStr = package_data?.header?.status?.toLowerCase()
+        if (statusStr == null || ['current', 'expected'].contains(statusStr)) {
           pkg = new Pkg(
                 name: package_data.header.packageName,
                source: package_data.header.packageSource,


### PR DESCRIPTION
- Added a check to see if the package status is null, defaulting to allow import in this case.
- Case insensitivity added to the checks for "current" and "expected"