### PR TITLE
ERM-866 Tweaked coverage date checking

### DIFF
--- a/service/grails-app/services/org/olf/ImportService.groovy
+++ b/service/grails-app/services/org/olf/ImportService.groovy
@@ -240,7 +240,8 @@ class ImportService implements DataBinder {
         ) {
             siblingInstanceIdentifier.namespace = 'ISBN'
             instanceIdentifier.namespace = 'ISBN'
-            if (getFieldFromLine(lineAsArray, acceptedFields, 'CoverageStatement.startDate') != '') {
+            String coverageStartDate = getFieldFromLine(lineAsArray, acceptedFields, 'CoverageStatement.startDate')?.trim();
+            if (coverageStartDate != null && coverageStartDate != '' ) {
               log.error("Unexpected coverage information for title: ${getFieldFromLine(lineAsArray, acceptedFields, 'title')} of type: ${instanceMedia}")
             }
             kbartCoverageList = []


### PR DESCRIPTION
We were previously getting an unexpected match on empty coverage data in monographs, so I've tweaked the code to use `trim()` and check both for null and empty string values.