### PR TITLE
ERM-874: Expanded fields we accept from eHoldings entitlement API Call

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure(2) do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
   config.vm.box = "folio/testing-backend"
-  # config.vm.box_version  = "5.0.0-20200414.4050"
+  config.vm.box_version  = "5.0.0-20200414.4050"
   # config.vm.box_version = "5.0.0-20190612.2294"
   # config.vm.box_version = "5.0.0-20190604.2248"
   #config.vm.box_version = "5.0.0-20190419.1982"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure(2) do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
   config.vm.box = "folio/testing-backend"
-  config.vm.box_version  = "5.0.0-20200414.4050"
+  # config.vm.box_version  = "5.0.0-20200414.4050"
   # config.vm.box_version = "5.0.0-20190612.2294"
   # config.vm.box_version = "5.0.0-20190604.2248"
   #config.vm.box_version = "5.0.0-20190419.1982"

--- a/service/grails-app/domain/org/olf/erm/Entitlement.groovy
+++ b/service/grails-app/domain/org/olf/erm/Entitlement.groovy
@@ -10,6 +10,9 @@ import org.olf.kb.PackageContentItem
 import org.olf.kb.Pkg
 import org.olf.kb.PlatformTitleInstance
 
+//TODO REMOVE THIS BEFORE SUBMITTING
+import groovy.json.JsonOutput
+
 import com.k_int.okapi.remote_resources.OkapiLookup
 import com.k_int.web.toolkit.domain.traits.Clonable
 import grails.databinding.BindInitializer
@@ -63,7 +66,7 @@ public class Entitlement implements MultiTenant<Entitlement>, Clonable<Entitleme
   
   
   @OkapiLookup(
-    value = '${obj.authority?.toLowerCase() == "ekb-package" ? "/eholdings/packages" : "/eholdings/resources" }/${obj.reference}',
+    value = '${obj.authority?.toLowerCase() == "ekb-package" ? "/eholdings/packages" : "/eholdings/resources" }/${obj.reference}${obj.authority?.toLowerCase() == "ekb-package" ? "" : "?include=package" }',
     converter = {
       // delegate, owner and thisObject should be the instance of Entitlement
       final Entitlement outerEntitlement = delegate
@@ -71,18 +74,138 @@ public class Entitlement implements MultiTenant<Entitlement>, Clonable<Entitleme
       log.debug "Converter called with delegate: ${outerEntitlement} and it: ${it}"
       
       final String theType = it.data?.attributes?.publicationType ?:
-         it.data?.type?.replaceAll(/^\s*([\S])(.*?)s?\s*$/, {match, String firstChar, String nonePlural -> "${firstChar.toUpperCase()}${nonePlural}"})
+        it.data?.type?.replaceAll(/^\s*([\S])(.*?)s?\s*$/, {match, String firstChar, String nonePlural -> "${firstChar.toUpperCase()}${nonePlural}"})
       
       def map = [
         label: it.data?.attributes?.name,
         type: (theType),
         provider: it.data?.attributes?.providerName
       ]
-      
-      def count = it.data?.attributes?.titleCount
-      if (count) {
-        map.titleCount = count
+
+      if (it.data?.type == "packages") {
+        // We're dealing with a package
+
+        def titleCount = it.data?.attributes?.titleCount
+        // Groovy truth evaluates 0 to false
+        if (titleCount != null) {
+          map.titleCount = titleCount
+        }
+
+        def selectedCount = it.data?.attributes?.selectedCount
+        // Groovy truth evaluates 0 to false
+        if (selectedCount != null) {
+          map.selectedCount = selectedCount
+        }
+
+        def contentType = it.data?.attributes?.contentType
+        if (contentType) {
+          map.contentType = contentType
+        }
+      } else {
+        // We're dealing with a title
+        def publicationType = it.data?.attributes?.publicationType
+        if (publicationType) {
+          map.publicationType = publicationType
+        }
+
+        def edition = it.data?.attributes?.edition
+        if (edition) {
+          map.edition = edition
+        }
+
+        def identifiers = it.data?.attributes?.identifiers
+        if (identifiers) {
+          def combinedIdentifiers = [];
+          identifiers.each {
+            def identifier = [id: it.id, type: "${it.type} (${it.subtype})"]
+            combinedIdentifiers << identifier
+          }
+          map.identifiers = combinedIdentifiers
+        }
+
+        def contributors = it.data?.attributes?.contributors
+        if (contributors) {
+          def authors = []
+          def editors = []
+          contributors.each {
+            if (it.type == "author") {
+              authors << it.contributor
+            } else if (it.type == "editor") {
+              editors << it.contributor
+            }
+          }
+          if (authors.size() > 0) {
+            map.authors = authors
+          }
+           if (editors.size() > 0) {
+            map.editors = editors
+          }
+        }
+        
+        Map packageData = [:]
+        def packageId = it.data?.attributes?.packageId
+        def includedPackage = it?.included.find { it.id == packageId && it.type == "packages"  }
+        if (includedPackage) {
+          def name = includedPackage.attributes?.name
+          if (name) {
+            packageData.name = name
+          }
+
+          def titleCount = includedPackage.attributes?.titleCount
+          // Groovy truth evaluates 0 to false
+          if (titleCount != null) {
+            packageData.titleCount = titleCount
+          }
+
+          def selectedCount = includedPackage.attributes?.selectedCount
+          // Groovy truth evaluates 0 to false
+          if (selectedCount != null) {
+            packageData.selectedCount = selectedCount
+          }
+
+          def contentType = includedPackage.attributes?.contentType
+          if (contentType) {
+            packageData.contentType = contentType
+          }
+
+          def providerName = includedPackage.attributes?.providerName
+          if (providerName) {
+            packageData.providerName = providerName
+          }
+
+          def isSelected = includedPackage.attributes?.isSelected
+          if (isSelected) {
+            packageData.isSelected = isSelected
+          }
+        }
+        if (packageData) {
+          map.packageData = packageData
+        }
       }
+
+      // These need to be added to the map whether the type is resource OR package
+      def providerName = it.data?.attributes?.providerName
+      if (providerName) {
+        map.providerName = providerName
+      }
+
+      def isSelected = it.data?.attributes?.isSelected
+      if (isSelected) {
+        map.isSelected = isSelected
+      }
+
+      def relationshipsAccessTypeDataId = it.data?.relationships?.accessType?.data?.id;
+      def accessStatusType;
+      if (relationshipsAccessTypeDataId) {
+
+        def includesMatchingId = it?.included.find { it.id == relationshipsAccessTypeDataId && it.type == "accessTypes"  }
+        accessStatusType = includesMatchingId?.attributes?.name
+
+        if (accessStatusType) {
+          map.accessStatusType = accessStatusType
+        }
+      }
+      log.debug("DEBUG MAP: ${JsonOutput.prettyPrint(JsonOutput.toJson(map))}")
       
       // Merge external coverages.
       final boolean isPackage = theType?.toLowerCase() == 'package'

--- a/service/grails-app/domain/org/olf/erm/Entitlement.groovy
+++ b/service/grails-app/domain/org/olf/erm/Entitlement.groovy
@@ -10,9 +10,6 @@ import org.olf.kb.PackageContentItem
 import org.olf.kb.Pkg
 import org.olf.kb.PlatformTitleInstance
 
-//TODO REMOVE THIS BEFORE SUBMITTING
-import groovy.json.JsonOutput
-
 import com.k_int.okapi.remote_resources.OkapiLookup
 import com.k_int.web.toolkit.domain.traits.Clonable
 import grails.databinding.BindInitializer
@@ -205,7 +202,6 @@ public class Entitlement implements MultiTenant<Entitlement>, Clonable<Entitleme
           map.accessStatusType = accessStatusType
         }
       }
-      log.debug("DEBUG MAP: ${JsonOutput.prettyPrint(JsonOutput.toJson(map))}")
       
       // Merge external coverages.
       final boolean isPackage = theType?.toLowerCase() == 'package'


### PR DESCRIPTION
We now accept enough data to output the following objects.

For a package:
```
{
    "label": "EBSCO eBooks",
    "type": "Package",
    "provider": "EBSCO",
    "titleCount": 1902197,
    "selectedCount": 1902193,
    "contentType": "E-Book",
    "providerName": "EBSCO",
    "isSelected": true,
    "accessStatusType": "Trial"
}
```

For a title:
```
{
    "label": "Alice in Wonderland and Through the Looking Glass",
    "type": "Book",
    "provider": "EBSCO",
    "publicationType": "Book",
    "identifiers": [
        {
            "id": "978-1-84002-256-8",
            "type": "ISBN (Print)"
        },
        {
            "id": "978-1-84943-747-9",
            "type": "ISBN (Online)"
        }
    ],
    "authors": [
        "Lewis Carroll"
    ],
    "editors": [
        "An Editor"
    ],
    "packageData": {
        "name": "EBSCO eBooks",
        "titleCount": 1902197,
        "selectedCount": 1902193,
        "contentType": "E-Book",
        "providerName": "EBSCO",
        "isSelected": true
    },
    "providerName": "EBSCO",
    "isSelected": true,
    "accessStatusType": "Subscription"
}
```