### PR TITLE
Inline validation updates

### DIFF
--- a/service/grails-app/controllers/org/olf/UrlMappings.groovy
+++ b/service/grails-app/controllers/org/olf/UrlMappings.groovy
@@ -161,7 +161,7 @@ class UrlMappings {
 //    "/export/future/$format?"   (controller: 'export', action: 'future', method: 'GET')
 //    "/export/dropped/$format?"  (controller: 'export', action: 'dropped', method: 'GET')
 
-    // Use kiwt namespace
-    "/kiwt/validate/$domain/$prop?" (controller: 'validate', method: 'POST')
+
+    "/erm/validate/$domain/$prop?" (controller: 'validate', method: 'POST')
   }
 }

--- a/service/grails-app/domain/org/olf/erm/AgreementRelationship.groovy
+++ b/service/grails-app/domain/org/olf/erm/AgreementRelationship.groovy
@@ -15,7 +15,7 @@ public class AgreementRelationship implements MultiTenant<AgreementRelationship>
   String id
   
   @CategoryId(defaultInternal=true)
-  @Defaults(['Supersedes', 'Provides post-cancellation access for', 'Tracks demand-driven acquisitions for'])
+  @Defaults(['Supersedes', 'Provides post-cancellation access for', 'Tracks demand-driven acquisitions for', 'Related to', 'Has backfile in'])
   RefdataValue type
   
   SubscriptionAgreement inward

--- a/service/grails-app/domain/org/olf/erm/SubscriptionAgreement.groovy
+++ b/service/grails-app/domain/org/olf/erm/SubscriptionAgreement.groovy
@@ -225,7 +225,7 @@ public class SubscriptionAgreement implements CustomProperties,MultiTenant<Subsc
   }
 
   static constraints = {
-                    name(nullable:false, blank:false)
+                    name(nullable:false, blank:false, unique: true)
           localReference(nullable:true, blank:false)
          vendorReference(nullable:true, blank:false)
              renewalDate(nullable:true, blank:false)

--- a/service/grails-app/i18n/messages.properties
+++ b/service/grails-app/i18n/messages.properties
@@ -69,3 +69,5 @@ agreements.not.relate.to.self=Agreements can not be related to themselves
 
 # Local KB external sources name not unique
 org.olf.kb.RemoteKB.name.unique=External data source was not saved. Name must be unique. A data source with the name "{2}" already exists
+
+org.olf.erm.SubscriptionAgreement.name.unique=Agreement was not saved. Name must be unique An agreement with the name "{2}" already exists

--- a/service/grails-app/migrations/update-mod-agreements-2-3.groovy
+++ b/service/grails-app/migrations/update-mod-agreements-2-3.groovy
@@ -161,7 +161,7 @@ databaseChangeLog = {
   }
 
   changeSet(author: "efreestone (manual)", id: "20200519-1626-001") {
-    addUniqueConstraint(tableName: "subscription_agreement", columnName: "sa_name")
+    addUniqueConstraint(tableName: "subscription_agreement", constraintName: "UC_SUBSCRIPTION_AGREEMENT_NAME_COL", columnNames: "sa_name")
   }
 }
 

--- a/service/grails-app/migrations/update-mod-agreements-2-3.groovy
+++ b/service/grails-app/migrations/update-mod-agreements-2-3.groovy
@@ -141,5 +141,27 @@ databaseChangeLog = {
       }
     }
   }
+
+
+  changeSet(author: "efreestone (manual)", id: "20200519-1102-001") {
+     grailsChange {
+      change {
+        // Return the list of names that have duplicates
+        List nonUniqueNames = sql.rows("SELECT sa.sa_name FROM diku_mod_agreements.subscription_agreement as sa GROUP BY sa.sa_name HAVING COUNT(*) > 1")
+        nonUniqueNames.each{
+          // For each of those names, return a list of the agreement ids that have that name
+          List rowsWithGivenName = sql.rows("SELECT sa_id FROM diku_mod_agreements.subscription_agreement as sa WHERE sa.sa_name = :name", [name: it.sa_name])
+          rowsWithGivenName.eachWithIndex {agreement, i ->
+            // For each of those ids, add an increment, so ["A", "A", "A"] becomes ["A_1", "A_2", "A_3"]
+            sql.execute("UPDATE ${database.defaultSchemaName}.subscription_agreement SET sa_name = CONCAT(sa_name, CONCAT('_', :index)) WHERE sa_id = :id", [id: agreement.sa_id, index: i + 1])
+          }
+        }
+      }
+    }
+  }
+
+  changeSet(author: "efreestone (manual)", id: "20200519-1626-001") {
+    addUniqueConstraint(tableName: "subscription_agreement", columnName: "sa_name")
+  }
 }
 

--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -75,7 +75,6 @@
           "pathPattern": "/erm/sas/{id}",
           "permissionsRequired": [ "erm.agreements.item.delete" ]
         },
-        
         {
           "methods": ["GET"],
           "pathPattern": "/export",
@@ -317,6 +316,26 @@
           "methods": ["POST"],
           "pathPattern": "/erm/packages/import",
           "permissionsRequired": [ "erm.packages.collection.import" ]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/erm/validate/subscriptionAgreement",
+          "permissionsRequired": [ "erm.agreements.item.post", "erm.agreements.item.put" ]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/erm/validate/subscriptionAgreement/*",
+          "permissionsRequired": [ "erm.agreements.item.post", "erm.agreements.item.put" ]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/erm/validate/remoteKB",
+          "permissionsRequired": [ "erm.kbs.item.post", "erm.kbs.item.put" ]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/erm/validate/remoteKB/*",
+          "permissionsRequired": [ "erm.kbs.item.post", "erm.kbs.item.put" ]
         }
       ]
     },{


### PR DESCRIPTION
- Added uniqueness validation to Agreement names
- exposed validation endpoints through Okapi
- added i18n message for non-unique agreement names
- migrations to append integers to existing non-unique names so A, A, A becomes A_1, A_2, A_3