### PR TITLE
ERM-891: Feature/inline validation, Require agreement names to be unique

### DIFF
--- a/service/grails-app/controllers/org/olf/UrlMappings.groovy
+++ b/service/grails-app/controllers/org/olf/UrlMappings.groovy
@@ -1,5 +1,7 @@
 package org.olf
 
+import org.olf.erm.SubscriptionAgreement
+
 class UrlMappings {
 
   static mappings = {
@@ -57,6 +59,10 @@ class UrlMappings {
         '/usageDataProviders' {
           controller = 'usageDataProvider'
           method = 'GET'
+        }
+        
+        "/validate/$prop?" (controller: 'validate', method: 'POST') {
+          domain = SubscriptionAgreement.class.name
         }
       }
     }
@@ -155,5 +161,7 @@ class UrlMappings {
 //    "/export/future/$format?"   (controller: 'export', action: 'future', method: 'GET')
 //    "/export/dropped/$format?"  (controller: 'export', action: 'dropped', method: 'GET')
 
+    // Use kiwt namespace
+    "/kiwt/validate/$domain/$prop?" (controller: 'validate', method: 'POST')
   }
 }

--- a/service/grails-app/controllers/org/olf/UrlMappings.groovy
+++ b/service/grails-app/controllers/org/olf/UrlMappings.groovy
@@ -161,7 +161,7 @@ class UrlMappings {
 //    "/export/future/$format?"   (controller: 'export', action: 'future', method: 'GET')
 //    "/export/dropped/$format?"  (controller: 'export', action: 'dropped', method: 'GET')
 
-    // Use kiwt namespace
-    "/kiwt/validate/$domain/$prop?" (controller: 'validate', method: 'POST')
+
+    "/erm/validate/$domain/$prop?" (controller: 'validate', method: 'POST')
   }
 }

--- a/service/grails-app/controllers/org/olf/ValidateController.groovy
+++ b/service/grails-app/controllers/org/olf/ValidateController.groovy
@@ -1,0 +1,75 @@
+package org.olf
+
+import static org.springframework.http.HttpStatus.*
+
+import org.grails.datastore.mapping.model.PersistentEntity
+
+import com.k_int.web.toolkit.utils.DomainUtils
+
+import grails.core.GrailsApplication
+import grails.gorm.multitenancy.CurrentTenant
+import groovy.util.logging.Slf4j
+
+@Slf4j
+@CurrentTenant
+class ValidateController {
+  
+  static responseFormats = ['json', 'xml']
+  static allowedMethods = [index: ["POST", "PATCH", "PUT"]]
+  
+  GrailsApplication grailsApplication
+  
+  def index(String domain, String prop) {
+    
+    // Try and locate the Domain class.
+    PersistentEntity target = DomainUtils.findDomainClass(domain)
+    
+    // Do the 
+    Class type
+    if (!(target)) {
+      return notFound();
+    }
+    
+    // Create instance of object to validate.
+    def object = target.newInstance()
+    
+    // Handle the id specially.
+    def bindings = getObjectToBind()
+    
+    String idName = target.getIdentity().name
+    
+    if (idName) {
+      object[idName] = bindings."${idName}"
+    }
+    
+    // Bind the supplied properties.
+    bindData(object, bindings)
+    
+    // Validate and respond with error messages and appropriate error code..
+    if (prop) {
+      // Validate only the single property.
+      object.validate([prop])
+    } else {
+      // Validate entire object.
+      object.validate()
+    }
+    if (object.hasErrors()) {
+        respond object.errors
+        return
+    }
+    
+    // If all is well we should just respond with a NO_CONTENT response code. Denoting a successful
+    // request without any content being returned.
+    render (status : NO_CONTENT)
+  }
+  
+  protected notFound () {
+    // Not found response.
+    render (status : NOT_FOUND)
+    return
+  }
+  
+  protected getObjectToBind() {
+    request.JSON
+  }
+}

--- a/service/grails-app/domain/org/olf/erm/AgreementRelationship.groovy
+++ b/service/grails-app/domain/org/olf/erm/AgreementRelationship.groovy
@@ -15,7 +15,7 @@ public class AgreementRelationship implements MultiTenant<AgreementRelationship>
   String id
   
   @CategoryId(defaultInternal=true)
-  @Defaults(['Supersedes', 'Provides post-cancellation access for', 'Tracks demand-driven acquisitions for'])
+  @Defaults(['Supersedes', 'Provides post-cancellation access for', 'Tracks demand-driven acquisitions for', 'Related to', 'Has backfile in'])
   RefdataValue type
   
   SubscriptionAgreement inward

--- a/service/grails-app/domain/org/olf/erm/SubscriptionAgreement.groovy
+++ b/service/grails-app/domain/org/olf/erm/SubscriptionAgreement.groovy
@@ -225,7 +225,7 @@ public class SubscriptionAgreement implements CustomProperties,MultiTenant<Subsc
   }
 
   static constraints = {
-                    name(nullable:false, blank:false)
+                    name(nullable:false, blank:false, unique: true)
           localReference(nullable:true, blank:false)
          vendorReference(nullable:true, blank:false)
              renewalDate(nullable:true, blank:false)

--- a/service/grails-app/i18n/messages.properties
+++ b/service/grails-app/i18n/messages.properties
@@ -69,3 +69,5 @@ agreements.not.relate.to.self=Agreements can not be related to themselves
 
 # Local KB external sources name not unique
 org.olf.kb.RemoteKB.name.unique=External data source was not saved. Name must be unique. A data source with the name "{2}" already exists
+
+org.olf.erm.SubscriptionAgreement.name.unique=Agreement was not saved. Name must be unique An agreement with the name "{2}" already exists

--- a/service/grails-app/migrations/update-mod-agreements-2-3.groovy
+++ b/service/grails-app/migrations/update-mod-agreements-2-3.groovy
@@ -141,5 +141,27 @@ databaseChangeLog = {
       }
     }
   }
+
+
+  changeSet(author: "efreestone (manual)", id: "20200519-1102-001") {
+     grailsChange {
+      change {
+        // Return the list of names that have duplicates
+        List nonUniqueNames = sql.rows("SELECT sa.sa_name FROM diku_mod_agreements.subscription_agreement as sa GROUP BY sa.sa_name HAVING COUNT(*) > 1")
+        nonUniqueNames.each{
+          // For each of those names, return a list of the agreement ids that have that name
+          List rowsWithGivenName = sql.rows("SELECT sa_id FROM diku_mod_agreements.subscription_agreement as sa WHERE sa.sa_name = :name", [name: it.sa_name])
+          rowsWithGivenName.eachWithIndex {agreement, i ->
+            // For each of those ids, add an increment, so ["A", "A", "A"] becomes ["A_1", "A_2", "A_3"]
+            sql.execute("UPDATE ${database.defaultSchemaName}.subscription_agreement SET sa_name = CONCAT(sa_name, CONCAT('_', :index)) WHERE sa_id = :id", [id: agreement.sa_id, index: i + 1])
+          }
+        }
+      }
+    }
+  }
+
+  changeSet(author: "efreestone (manual)", id: "20200519-1626-001") {
+    addUniqueConstraint(tableName: "subscription_agreement", constraintName: "UC_SUBSCRIPTION_AGREEMENT_NAME_COL", columnNames: "sa_name")
+  }
 }
 

--- a/service/grails-app/views/errors/_errors.gson
+++ b/service/grails-app/views/errors/_errors.gson
@@ -10,33 +10,20 @@ model {
 response.status UNPROCESSABLE_ENTITY
 
 json {
-    Errors errorsObject = (Errors)this.errors
-    def allErrors = errorsObject.allErrors
-    int errorCount = allErrors.size()
-    def resourcePath = g.link(resource:request.uri, absolute:false)
-    def resourceLink = g.link(resource:request.uri, absolute:true)
-    if(errorCount == 1) {
-        def error = allErrors.iterator().next()
-        message messageSource.getMessage(error, locale)
-        path resourcePath
-        _links {
-            self {
-                href resourceLink
-            }
-        }
+  Errors errorsObject = (Errors)this.errors
+  List<ObjectError> allErrors = errorsObject.allErrors
+  int errorCount = allErrors.size()
+  total errorCount
+  errors(allErrors) { ObjectError error ->
+    code error.code
+//    codes error.codes
+    object error.objectName
+    if (error instanceof FieldError) {
+      FieldError fError = error as FieldError
+      i18n_code "${error.objectName}.${fError.field}.${error.code}"
+    } else {
+      i18n_code "${error.objectName}.${error.code}"
     }
-    else {
-        total errorCount
-        _embedded {
-            errors(allErrors) { ObjectError error ->
-                message messageSource.getMessage(error, locale)
-                path resourcePath
-                _links {
-                    self {
-                        href resourceLink
-                    }
-                }
-            }
-        }
-    }
+    message messageSource.getMessage(error, locale)
+  }
 }

--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -75,7 +75,6 @@
           "pathPattern": "/erm/sas/{id}",
           "permissionsRequired": [ "erm.agreements.item.delete" ]
         },
-        
         {
           "methods": ["GET"],
           "pathPattern": "/export",
@@ -317,6 +316,26 @@
           "methods": ["POST"],
           "pathPattern": "/erm/packages/import",
           "permissionsRequired": [ "erm.packages.collection.import" ]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/erm/validate/subscriptionAgreement",
+          "permissionsRequired": [ "erm.agreements.item.post", "erm.agreements.item.put" ]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/erm/validate/subscriptionAgreement/*",
+          "permissionsRequired": [ "erm.agreements.item.post", "erm.agreements.item.put" ]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/erm/validate/remoteKB",
+          "permissionsRequired": [ "erm.kbs.item.post", "erm.kbs.item.put" ]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/erm/validate/remoteKB/*",
+          "permissionsRequired": [ "erm.kbs.item.post", "erm.kbs.item.put" ]
         }
       ]
     },{


### PR DESCRIPTION
This PR adds the validation endpoints previously set up by Steve, a uniqueness constraint on agreement names and migrations for existing non-unique names. 

Also exposed the new endpoints and added an i18n message for non-unique agreement names.