### PR TITLE
ERM-925, ERM-929, ERM-930, ERM-931: AgreementLine info and tags added to export

### DIFF
--- a/service/grails-app/controllers/org/olf/ExportController.groovy
+++ b/service/grails-app/controllers/org/olf/ExportController.groovy
@@ -53,7 +53,7 @@ class ExportController extends OkapiTenantAwareController<TitleInstance>  {
     respondWithResults ( results )
   }
   
-  private respondWithResults (List<ErmResource> results) {
+  private respondWithResults (List<List> results) {
     
     withFormat {
       'kbart' {

--- a/service/grails-app/controllers/org/olf/ExportController.groovy
+++ b/service/grails-app/controllers/org/olf/ExportController.groovy
@@ -37,7 +37,7 @@ class ExportController extends OkapiTenantAwareController<TitleInstance>  {
     log.debug("ExportController::index")
     final String subscriptionAgreementId = params.get("subscriptionAgreementId")
     log.debug("Getting export for specific agreement: "+ subscriptionAgreementId)
-    List<ErmResource> results = exportService.all(subscriptionAgreementId)
+    List<List> results = exportService.all(subscriptionAgreementId)
     log.debug("found this many resources: "+ results.size())
     
     respondWithResults ( results )
@@ -47,7 +47,7 @@ class ExportController extends OkapiTenantAwareController<TitleInstance>  {
     log.debug("ExportController::index")
     final String subscriptionAgreementId = params.get("subscriptionAgreementId")
     log.debug("Getting export for specific agreement: "+ subscriptionAgreementId)
-    List<ErmResource> results = exportService.current(subscriptionAgreementId)
+    List<List> results = exportService.current(subscriptionAgreementId)
     log.debug("found this many resources: "+ results.size())
     
     respondWithResults ( results )

--- a/service/grails-app/services/org/olf/ExportService.groovy
+++ b/service/grails-app/services/org/olf/ExportService.groovy
@@ -39,7 +39,7 @@ public class ExportService {
     agreement
   }
    
-  List<ErmResource> all(final String agreementId = null) {
+  List<List> all(final String agreementId = null) {
     def results = null
     if (agreementId) {
       results = ErmResource.executeQuery("""
@@ -99,7 +99,7 @@ public class ExportService {
     return results  
   }
   
-  List<ErmResource> current (final String agreementId = null) {
+  List<List> current (final String agreementId = null) {
     final LocalDate today = LocalDate.now()
     
     def results = null

--- a/service/grails-app/views/export/_exportEntry.gson
+++ b/service/grails-app/views/export/_exportEntry.gson
@@ -68,7 +68,9 @@ json {
     }
   }
   
-  agreementLine g.render(ent, [includes:["id", "tags", "suppressFromDiscovery"], expand:["tags"]])
+  "agreementLine" g.render(ent, [includes:["id", "suppressFromDiscovery"]]) {
+    tags g.render(ent.tags)
+  }
 
   if (the_platform) {
      platform g.render(the_platform)

--- a/service/grails-app/views/export/_exportEntry.gson
+++ b/service/grails-app/views/export/_exportEntry.gson
@@ -34,6 +34,7 @@ switch (resource) {
     break
   case { it instanceof PlatformTitleInstance }:
     PlatformTitleInstance pti = resource as PlatformTitleInstance
+    ent = GrailsHibernateUtil.unwrapIfProxy(tuple[2]) as Entitlement
     ti = pti.titleInstance
     the_platform = pti.platform
     the_url = pti.url

--- a/service/grails-app/views/export/_exportEntry.gson
+++ b/service/grails-app/views/export/_exportEntry.gson
@@ -55,6 +55,9 @@ Map customCoverageMap = request?.getAttribute("${controllerName}.${actionName}.c
 List customCoverageList = customCoverageMap?.get("${resource.id}") 
 
 json {
+
+  tags g.render(resource.tags)
+
   if (via_package) {
     final def pkg = ent.resource
     
@@ -100,7 +103,7 @@ json {
     'customCoverage' false
   }
   
-  title g.render(ti, [expand: ['identifiers', 'type', 'subType'], excludes: ['entitlements', 'coverage', 'work', 'platformInstances']])
+  title g.render(ti, [expand: ['identifiers', 'type', 'subType', 'tags'], excludes: ['entitlements', 'coverage', 'work', 'platformInstances']])
 
 }
 

--- a/service/grails-app/views/export/_exportEntry.gson
+++ b/service/grails-app/views/export/_exportEntry.gson
@@ -68,6 +68,7 @@ json {
     }
   }
   
+  agreementLine g.render(ent, [includes:["id", "tags", "suppressFromDiscovery"], expand:["tags"]])
 
   if (the_platform) {
      platform g.render(the_platform)


### PR DESCRIPTION
For each resource under "resources" on an agreement export, there is now an "agreementLine" section, containing the entitlement id, suppressFromDiscovery flag and any tags on that entitlement.

In addition, tags on the TI, PCI or PTI will now show up in the export, and a bug was fixed where the entitlement information was not grabbed in the PTI resource case.