### PR TITLE
ERM-993 Ensure import moves to next line if no publication_type

### DIFF
--- a/service/grails-app/services/org/olf/ImportService.groovy
+++ b/service/grails-app/services/org/olf/ImportService.groovy
@@ -234,6 +234,7 @@ class ImportService implements DataBinder {
       if (!instanceMedia) {
         // Skip the import 
         log.error "Missing publication_type for title: ${getFieldFromLine(record, acceptedFields, 'title')}, skipping line."
+        record = file.readNext()
       } else {
         if (
           instanceMedia.toLowerCase() == 'monograph' ||


### PR DESCRIPTION
The KBART import could get stuck in a loop - this stops that happening