### PR TITLE
ERM-943 Separate ERM 'publication type' from 'type'

### DIFF
--- a/service/grails-app/domain/org/olf/kb/ErmResource.groovy
+++ b/service/grails-app/domain/org/olf/kb/ErmResource.groovy
@@ -19,6 +19,7 @@ public class ErmResource extends ErmTitleList implements MultiTenant<ErmResource
   String description
   
   RefdataValue type
+  RefdataValue publicationType
   RefdataValue subType
 
   Date dateCreated
@@ -41,6 +42,7 @@ public class ErmResource extends ErmTitleList implements MultiTenant<ErmResource
                    name column: 'res_name'
             description column: 'res_description', type:'text'
                    type column: 'res_type_fk'
+        publicationType column: 'res_publication_type_fk'
             dateCreated column: 'res_date_created'
             lastUpdated column: 'res_last_updated'
                 subType column: 'res_sub_type_fk'
@@ -53,6 +55,7 @@ public class ErmResource extends ErmTitleList implements MultiTenant<ErmResource
                    name (nullable:true, blank:false)
             description (nullable:true, blank:false)
                    type (nullable:true, blank:false)
+        publicationType (nullable:true, blank:false)
                 subType (nullable:true, blank:false)
             dateCreated (nullable:true, blank:false)
             lastUpdated (nullable:true, blank:false)

--- a/service/grails-app/domain/org/olf/kb/TitleInstance.groovy
+++ b/service/grails-app/domain/org/olf/kb/TitleInstance.groovy
@@ -51,8 +51,13 @@ public class TitleInstance extends ErmResource implements MultiTenant<TitleInsta
   Work work
   
   // Journal/Book/...
+  @CategoryId(defaultInternal=false)
+  @Defaults(['Book', 'Journal', 'Monograph', 'Serial'])
+  RefdataValue publicationType
+
+  // serial / monograph system
   @CategoryId(defaultInternal=true)
-  @Defaults(['Journal', 'Book'])
+  @Defaults(['Monograph', 'Serial'])
   RefdataValue type
 
   // Print/Electronic
@@ -79,9 +84,10 @@ public class TitleInstance extends ErmResource implements MultiTenant<TitleInsta
   ]
 
   static mapping = {
-                          work column:'ti_work_fk'
-                          type column:'ti_type_fk'
-                       subType column:'ti_subtype_fk'
+                          work column: 'ti_work_fk'
+                          type column: 'ti_type_fk'
+                       subType column: 'ti_subtype_fk'
+               publicationType column: 'ti_publication_type_fk'
         dateMonographPublished column: 'ti_date_monograph_published'
                    firstAuthor column: 'ti_first_author'
                    firstEditor column: 'ti_first_editor'

--- a/service/grails-app/migrations/update-mod-agreements-2-4.groovy
+++ b/service/grails-app/migrations/update-mod-agreements-2-4.groovy
@@ -99,4 +99,80 @@ databaseChangeLog = {
     changeSet(author: "sosguthorpe (generated)", id: "1593002234734-7") {
       addPrimaryKey(columnNames: "id", constraintName: "kbart_import_jobPK", tableName: "kbart_import_job")
     }
+
+    /** add publicationType, move existing refdata values of TitleInstance.Type to TitleInstance.PublicationType **/
+    changeSet(author: "claudia (manual)", id: "202007271150-01") {
+      addColumn(tableName: "erm_resource") {
+        column(name: "res_publication_type_fk", type: "VARCHAR(36)")
+      }
+    }
+
+    changeSet(author: "claudia (manual)", id: "202007271150-02") {
+      addForeignKeyConstraint(baseColumnNames: "res_publication_type_fk", baseTableName: "erm_resource", constraintName: "pub_type_to_erm", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
+    }
+
+    // set res_publication_type_fk to the value of res_type_fk for values 'book', 'journal', 'serial'
+    changeSet(author: "claudia (manual)", id: "202007271150-03") {
+      grailsChange {
+        change {
+          sql.execute("UPDATE ${database.defaultSchemaName}.erm_resource SET res_publication_type_fk = (SELECT rdv_id FROM ${database.defaultSchemaName}.refdata_value INNER JOIN ${database.defaultSchemaName}.refdata_category ON refdata_value.rdv_owner = refdata_category.rdc_id WHERE rdc_description='TitleInstance.PublicationType' AND rdv_value='book') WHERE res_type_fk=(SELECT rdv_id FROM ${database.defaultSchemaName}.refdata_value INNER JOIN ${database.defaultSchemaName}.refdata_category ON refdata_value.rdv_owner = refdata_category.rdc_id WHERE rdc_description='TitleInstance.Type' AND rdv_value='book')".toString())
+        }
+      }  
+    }
+
+    changeSet(author: "claudia (manual)", id: "202007271150-04") {
+      grailsChange {
+        change {
+          sql.execute("UPDATE ${database.defaultSchemaName}.erm_resource SET res_publication_type_fk = (SELECT rdv_id FROM ${database.defaultSchemaName}.refdata_value INNER JOIN ${database.defaultSchemaName}.refdata_category ON refdata_value.rdv_owner = refdata_category.rdc_id WHERE rdc_description='TitleInstance.PublicationType' AND rdv_value='journal') WHERE res_type_fk=(SELECT rdv_id FROM ${database.defaultSchemaName}.refdata_value INNER JOIN ${database.defaultSchemaName}.refdata_category ON refdata_value.rdv_owner = refdata_category.rdc_id WHERE rdc_description='TitleInstance.Type' AND rdv_value='journal')".toString())
+        }
+      }  
+    }
+
+    changeSet(author: "claudia (manual)", id: "202007271150-05") {
+      grailsChange {
+        change {
+          sql.execute("UPDATE ${database.defaultSchemaName}.erm_resource SET res_publication_type_fk = (SELECT rdv_id FROM ${database.defaultSchemaName}.refdata_value INNER JOIN ${database.defaultSchemaName}.refdata_category ON refdata_value.rdv_owner = refdata_category.rdc_id WHERE rdc_description='TitleInstance.PublicationType' AND rdv_value='serial') WHERE res_type_fk=(SELECT rdv_id FROM ${database.defaultSchemaName}.refdata_value INNER JOIN ${database.defaultSchemaName}.refdata_category ON refdata_value.rdv_owner = refdata_category.rdc_id WHERE rdc_description='TitleInstance.Type' AND rdv_value='serial')".toString())
+        }
+      }  
+    }
+
+    // set res_type_fk 'book' to 'monograph'
+    changeSet(author: "claudia (manual)", id: "202007271150-06") {
+      grailsChange {
+        change {
+          sql.execute("UPDATE ${database.defaultSchemaName}.erm_resource SET res_type_fk = (SELECT rdv_id FROM ${database.defaultSchemaName}.refdata_value INNER JOIN ${database.defaultSchemaName}.refdata_category ON refdata_value.rdv_owner = refdata_category.rdc_id WHERE rdc_description='TitleInstance.Type' AND rdv_value='monograph') WHERE res_type_fk=(SELECT rdv_id FROM ${database.defaultSchemaName}.refdata_value INNER JOIN ${database.defaultSchemaName}.refdata_category ON refdata_value.rdv_owner = refdata_category.rdc_id WHERE rdc_description='TitleInstance.Type' AND rdv_value='book')".toString())
+        }
+      }  
+    }
+
+    // set res_type_fk 'journal' to 'serial'
+    changeSet(author: "claudia (manual)", id: "202007271150-07") {
+      grailsChange {
+        change {
+          sql.execute("UPDATE ${database.defaultSchemaName}.erm_resource SET res_type_fk = (SELECT rdv_id FROM ${database.defaultSchemaName}.refdata_value INNER JOIN ${database.defaultSchemaName}.refdata_category ON refdata_value.rdv_owner = refdata_category.rdc_id WHERE rdc_description='TitleInstance.Type' AND rdv_value='serial') WHERE res_type_fk=(SELECT rdv_id FROM ${database.defaultSchemaName}.refdata_value INNER JOIN ${database.defaultSchemaName}.refdata_category ON refdata_value.rdv_owner = refdata_category.rdc_id WHERE rdc_description='TitleInstance.Type' AND rdv_value='journal')".toString())
+        }
+      }  
+    }
+
+    // delete refdata values 'book' and 'journal' for TitleInstance.Type
+    changeSet(author: "claudia (manual)", id: "202007271150-08") {
+      grailsChange {
+        change {
+          sql.execute("""
+            DELETE from ${database.defaultSchemaName}.refdata_value where rdv_value in ('book', 'journal') and rdv_owner=(select rdc_id from ${database.defaultSchemaName}.refdata_category where rdc_description = 'TitleInstance.Type')
+          """.toString())
+        }
+      }  
+    }
+
+    // fix typo for rdv_label capitalization
+    changeSet(author: "claudia (manual)", id: "202007271150-09") {
+      grailsChange {
+        change {
+          sql.execute("""
+            UPDATE ${database.defaultSchemaName}.refdata_value SET rdv_label = 'Serial' WHERE rdv_label = 'serial';
+          """.toString())
+        }
+      }
+    }
 }

--- a/service/grails-app/migrations/update-mod-agreements-2-4.groovy
+++ b/service/grails-app/migrations/update-mod-agreements-2-4.groovy
@@ -131,7 +131,7 @@ databaseChangeLog = {
     changeSet(author: "claudia (manual)", id: "202007271150-05") {
       grailsChange {
         change {
-          sql.execute("UPDATE ${database.defaultSchemaName}.erm_resource SET res_publication_type_fk = (SELECT rdv_id FROM ${database.defaultSchemaName}.refdata_value INNER JOIN ${database.defaultSchemaName}.refdata_category ON refdata_value.rdv_owner = refdata_category.rdc_id WHERE rdc_description='TitleInstance.PublicationType' AND rdv_value='serial') WHERE res_type_fk=(SELECT rdv_id FROM ${database.defaultSchemaName}.refdata_value INNER JOIN ${database.defaultSchemaName}.refdata_category ON refdata_value.rdv_owner = refdata_category.rdc_id WHERE rdc_description='TitleInstance.Type' AND rdv_value='serial')".toString())
+          sql.execute("UPDATE ${database.defaultSchemaName}.erm_resource SET res_publication_type_fk = (SELECT rdv_id FROM ${database.defaultSchemaName}.refdata_value INNER JOIN ${database.defaultSchemaName}.refdata_category ON refdata_value.rdv_owner = refdata_category.rdc_id WHERE rdc_description='TitleInstance.PublicationType' AND rdv_value='serial') WHERE res_publication_type_fk is null AND res_type_fk=(SELECT rdv_id FROM ${database.defaultSchemaName}.refdata_value INNER JOIN ${database.defaultSchemaName}.refdata_category ON refdata_value.rdv_owner = refdata_category.rdc_id WHERE rdc_description='TitleInstance.Type' AND rdv_value='serial')".toString())
         }
       }  
     }

--- a/service/grails-app/services/org/olf/ImportService.groovy
+++ b/service/grails-app/services/org/olf/ImportService.groovy
@@ -249,7 +249,7 @@ class ImportService implements DataBinder {
             siblingInstanceIdentifier.namespace = 'ISSN'
             instanceIdentifier.namespace = 'ISSN'
         } else { // only serial or monograph publication_type allowed for kbart import
-            log.error "publication_type \"${instanceMedia}\" not valid for kbart import, title: ${getFieldFromLine(record, acceptedFields, 'title')}, skipping line."
+            log.error "Invalid publication_type \"${instanceMedia}\" for title: ${getFieldFromLine(record, acceptedFields, 'title')}, skipping line."
             record = file.readNext()
             continue
         }

--- a/service/grails-app/services/org/olf/ImportService.groovy
+++ b/service/grails-app/services/org/olf/ImportService.groovy
@@ -236,10 +236,7 @@ class ImportService implements DataBinder {
         log.error "Missing publication_type for title: ${getFieldFromLine(record, acceptedFields, 'title')}, skipping line."
         record = file.readNext()
       } else {
-        if (
-          instanceMedia.toLowerCase() == 'monograph' ||
-          instanceMedia.toLowerCase() == 'book'
-        ) {
+        if ( instanceMedia.toLowerCase() == 'monograph' ) {
             siblingInstanceIdentifier.namespace = 'ISBN'
             instanceIdentifier.namespace = 'ISBN'
             String coverageStartDate = getFieldFromLine(record, acceptedFields, 'CoverageStatement.startDate')?.trim();
@@ -247,9 +244,12 @@ class ImportService implements DataBinder {
               log.error("Unexpected coverage information for title: ${getFieldFromLine(record, acceptedFields, 'title')} of type: ${instanceMedia}")
             }
             addCoverage = false
-        } else {          
+        } else if ( instanceMedia.toLowerCase() == 'serial' ) {
             siblingInstanceIdentifier.namespace = 'ISSN'
             instanceIdentifier.namespace = 'ISSN'
+        } else { // only serial or monograph publication_type allowed for kbart import
+            log.error "publication_type \"${instanceMedia}\" not valid for kbart import, title: ${getFieldFromLine(record, acceptedFields, 'title')}, skipping line."
+            record = file.readNext()
         }
 
         siblingInstanceIdentifier.value = getFieldFromLine(record, acceptedFields, 'siblingInstanceIdentifiers')

--- a/service/grails-app/services/org/olf/ImportService.groovy
+++ b/service/grails-app/services/org/olf/ImportService.groovy
@@ -235,6 +235,7 @@ class ImportService implements DataBinder {
         // Skip the import 
         log.error "Missing publication_type for title: ${getFieldFromLine(record, acceptedFields, 'title')}, skipping line."
         record = file.readNext()
+        continue
       } else {
         if ( instanceMedia.toLowerCase() == 'monograph' ) {
             siblingInstanceIdentifier.namespace = 'ISBN'
@@ -250,6 +251,7 @@ class ImportService implements DataBinder {
         } else { // only serial or monograph publication_type allowed for kbart import
             log.error "publication_type \"${instanceMedia}\" not valid for kbart import, title: ${getFieldFromLine(record, acceptedFields, 'title')}, skipping line."
             record = file.readNext()
+            continue
         }
 
         siblingInstanceIdentifier.value = getFieldFromLine(record, acceptedFields, 'siblingInstanceIdentifiers')

--- a/service/grails-app/services/org/olf/TitleEnricherService.groovy
+++ b/service/grails-app/services/org/olf/TitleEnricherService.groovy
@@ -35,7 +35,7 @@ class TitleEnricherService {
 
             if (!enrichedIdSet.contains(ti.id)) {
               // Only perform the enrichment if we've not already stored the id of this TI
-              Map titleInstanceEnrichmentValues = cache_updater.getTitleInstance(kb.name, kb.uri, sourceIdentifier, ti?.type?.value, ti?.subType?.value)
+              Map titleInstanceEnrichmentValues = cache_updater.getTitleInstance(kb.name, kb.uri, sourceIdentifier, ti?.type?.value, ti?.publicationType?.value, ti?.subType?.value)
               
               // If no enrichment values were returned then break out
               if (titleInstanceEnrichmentValues) {

--- a/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
+++ b/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
@@ -253,20 +253,29 @@ class TitleInstanceResolverService implements DataBinder{
       
       if ((resource_type?.length() ?: 0) > 0) {
         result.publicationTypeFromString = resource_type
-        if ( resource_type == 'monograph' || resource_type == 'book') {
-          result.typeFromString = 'monograph'
-        } else if ( resource_type == 'serial' || resource_type == 'journal') {
-          result.typeFromString = 'serial'
-        } else {
-          /**
-          ERM-987: ... check for the existence of a coverage statement.
-          If a coverage statement exists then type == "serial", otherwise "monograph"
-          **/
-           if ( resource_coverage ) {
-            result.typeFromString = 'serial'
-          } else {
+        switch(resource_type) {
+          case 'book':
             result.typeFromString = 'monograph'
-          }
+            break
+          case 'journal':
+            result.typeFromString = 'serial'
+            break
+          case 'monograph':
+            result.typeFromString = 'monograph'
+            break
+          case 'serial':
+            result.typeFromString = 'serial'
+            break
+          default:
+            /**
+            ERM-987: ... check for the existence of a coverage statement.
+            If a coverage statement exists then type == "serial", otherwise "monograph"
+            **/
+            if ( resource_coverage ) {
+              result.typeFromString = 'serial'
+            } else {
+              result.typeFromString = 'monograph'
+            }
         }
       }
 

--- a/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
+++ b/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
@@ -234,6 +234,7 @@ class TitleInstanceResolverService implements DataBinder{
 
       // Journal or Book etc
       def resource_type = citation.instanceMedia?.trim()
+      def resource_coverage = citation?.coverage
       result = new TitleInstance(
         name: citation.title,
 
@@ -251,7 +252,22 @@ class TitleInstanceResolverService implements DataBinder{
       }
       
       if ((resource_type?.length() ?: 0) > 0) {
-        result.typeFromString = resource_type
+        result.publicationTypeFromString = resource_type
+        if ( resource_type == 'monograph' || resource_type == 'book') {
+          result.typeFromString = 'monograph'
+        } else if ( resource_type == 'serial' || resource_type == 'journal') {
+          result.typeFromString = 'serial'
+        } else {
+          /**
+          ERM-987: ... check for the existence of a coverage statement.
+          If a coverage statement exists then type == "serial", otherwise "monograph"
+          **/
+           if ( resource_coverage ) {
+            result.typeFromString = 'serial'
+          } else {
+            result.typeFromString = 'monograph'
+          }
+        }
       }
 
       result.save(flush:true, failOnError:true)

--- a/service/grails-app/views/ermResource/_ermResource.gson
+++ b/service/grails-app/views/ermResource/_ermResource.gson
@@ -22,6 +22,10 @@ json {
     'type' g.render (ermResource.type)
   }
   
+  if (ermResource.publicationType) {
+    'publicationType' g.render (ermResource.publicationType)
+  }
+
   if (ermResource.subType) {
     'subType' g.render (ermResource.subType)
   }

--- a/service/grails-app/views/titleInstance/_titleInstance.gson
+++ b/service/grails-app/views/titleInstance/_titleInstance.gson
@@ -6,14 +6,14 @@ import groovy.transform.*
 @Field
 TitleInstance titleInstance
 
-json g.render(titleInstance, [expand: ['identifiers', 'type', 'subType', 'coverage', 'tags'], excludes: ['entitlements']]) {
+json g.render(titleInstance, [expand: ['identifiers', 'type', 'publicationType', 'subType', 'coverage', 'tags'], excludes: ['entitlements']]) {
   'class' titleInstance.class.name
   longName titleInstance.longName
   
   relatedTitles (titleInstance.relatedTitles) { TitleInstance relation ->
     
     // Also render a minimal title instance for the relation
-    g.inline (relation, [includes: ['id', 'name', 'type', 'subType', 'identifiers'], expand: ['type', 'subType', 'identifiers']]) {
+    g.inline (relation, [includes: ['id', 'name', 'type', 'publicationType', 'subType', 'identifiers'], expand: ['type', 'publicationType', 'subType', 'identifiers']]) {
       longName titleInstance.longName
     }
   }

--- a/service/src/main/groovy/org/olf/kb/KBCacheUpdater.groovy
+++ b/service/src/main/groovy/org/olf/kb/KBCacheUpdater.groovy
@@ -75,6 +75,7 @@ public interface KBCacheUpdater {
                               String base_url,
                               String identifier,
                               String type,
+                              String publicationType,
                               String subType);
   
   public boolean requiresSecondaryEnrichmentCall();

--- a/service/src/main/groovy/org/olf/kb/adapters/EbscoKBAdapter.groovy
+++ b/service/src/main/groovy/org/olf/kb/adapters/EbscoKBAdapter.groovy
@@ -268,6 +268,7 @@ public class EbscoKBAdapter implements KBCacheUpdater, DataBinder {
                               String base_url,
                               String identifier,
                               String type,
+                              String publicationType,
                               String subType) {
     throw new RuntimeException("Not supported by this KB provider");
   }

--- a/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
+++ b/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
@@ -220,6 +220,12 @@ public class GOKbOAIAdapter implements KBCacheUpdater, DataBinder {
             case 'BookInstance':
               tipp_media = 'book'
               break
+            case 'DatabaseInstance':
+              tipp_media = 'database'
+              break
+            case 'OtherInstance':
+              tipp_media = 'other'
+              break
             default:
               tipp_media = 'journal'
               break
@@ -314,9 +320,9 @@ public class GOKbOAIAdapter implements KBCacheUpdater, DataBinder {
     return false
   }
 
-  public Map getTitleInstance(String source_name, String base_url, String goKbIdentifier, String type, String subType) {
+  public Map getTitleInstance(String source_name, String base_url, String goKbIdentifier, String type, String publicationType, String subType) {
 
-    if (type.toLowerCase() == "book" || type.toLowerCase() == "monograph") {
+    if (publicationType.toLowerCase() == "book" || publicationType.toLowerCase() == "monograph") {
       log.debug("Making secondary enrichment call for book/monograph title with GOKb identifier: ${goKbIdentifier}")
       Map ti = [:];
 
@@ -347,7 +353,7 @@ public class GOKbOAIAdapter implements KBCacheUpdater, DataBinder {
       }
       return ti;
     } else {
-      log.debug("No secondary enrichment call needed for type: ${type}")
+      log.debug("No secondary enrichment call needed for publicationType: ${publicationType}")
     }
   }
 

--- a/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
+++ b/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
@@ -322,7 +322,7 @@ public class GOKbOAIAdapter implements KBCacheUpdater, DataBinder {
 
   public Map getTitleInstance(String source_name, String base_url, String goKbIdentifier, String type, String publicationType, String subType) {
 
-    if (publicationType.toLowerCase() == "book" || publicationType.toLowerCase() == "monograph") {
+    if (type.toLowerCase() == "monograph") {
       log.debug("Making secondary enrichment call for book/monograph title with GOKb identifier: ${goKbIdentifier}")
       Map ti = [:];
 

--- a/service/src/main/groovy/org/olf/kb/adapters/GenericRemoteKBAdapter.groovy
+++ b/service/src/main/groovy/org/olf/kb/adapters/GenericRemoteKBAdapter.groovy
@@ -60,6 +60,7 @@ public class GenericRemoteKBAdapter implements KBCacheUpdater {
                               String base_url,
                               String identifier,
                               String type,
+                              String publicationType,
                               String subType) {
     throw new RuntimeException("Not supported by this KB provider");
   }

--- a/service/src/main/groovy/org/olf/kb/adapters/KBPlusAdapter.groovy
+++ b/service/src/main/groovy/org/olf/kb/adapters/KBPlusAdapter.groovy
@@ -63,6 +63,7 @@ public class KBPlusAdapter implements KBCacheUpdater {
                               String base_url,
                               String identifier,
                               String type,
+                              String publicationType,
                               String subType) {
     throw new RuntimeException("Not supported by this KB provider");
   }

--- a/service/src/main/groovy/org/olf/kb/adapters/KIJPFAdapter.groovy
+++ b/service/src/main/groovy/org/olf/kb/adapters/KIJPFAdapter.groovy
@@ -163,6 +163,7 @@ public class KIJPFAdapter implements KBCacheUpdater {
                               String base_url,
                               String identifier,
                               String type,
+                              String publicationType,
                               String subType) {
     throw new RuntimeException("Not supported by this KB provider");
   }


### PR DESCRIPTION
- add publicationType refdata property to TitleInstance and ErmResource
- migrate type values to publicationType values in erm_resource
- change existing type values in erm_resource
- delete refdataValues for TitleInstance.type
- add publicationType to ermResource and titleInstance template
- add publication_type to kb adapters
- update import, title services
- refs ERM-984, ERM-986, ERM-987, ERM-988