### PR TITLE
Switched embargo moving wall start/end lengths from strings to numbers

### DIFF
--- a/service/grails-app/views/comparison/compare.gson
+++ b/service/grails-app/views/comparison/compare.gson
@@ -93,10 +93,10 @@ final mergeIntoObject = { final ComparisonPoint cp, final int totalSources, fina
 
       coverageEntry['embargo'] = [:]
       coverageEntry['embargo']['movingWallStart'] = [:]
-      coverageEntry['embargo']['movingWallStart']['length'] = emb.movingWallStart ? "${emb.movingWallStart.length}" : null
+      coverageEntry['embargo']['movingWallStart']['length'] = emb.movingWallStart ? emb.movingWallStart.length : null
       coverageEntry['embargo']['movingWallStart']['unit'] = emb.movingWallStart ? "${embargoUnit(emb.movingWallStart.unit)}" : null
       coverageEntry['embargo']['movingWallEnd'] = [:]
-      coverageEntry['embargo']['movingWallEnd']['length'] = emb.movingWallEnd ? "${emb.movingWallEnd.length}" : null
+      coverageEntry['embargo']['movingWallEnd']['length'] = emb.movingWallEnd ? emb.movingWallEnd.length : null
       coverageEntry['embargo']['movingWallEnd']['unit'] = emb.movingWallEnd ? "${embargoUnit(emb.movingWallEnd.unit)}" : null
     }
     


### PR DESCRIPTION
Embargo output didn't match embargo output elsewhere, which was causing proptype warnings in the frontend. This PR brings the embargo lengths into line with the way we render them elsewhere, as numbers instead of strings.