### PR TITLE
ERM-932: Added suppressToDiscovery to title level in resource export

### DIFF
--- a/service/grails-app/views/export/_exportEntry.gson
+++ b/service/grails-app/views/export/_exportEntry.gson
@@ -114,7 +114,7 @@ json {
     'customCoverage' false
   }
   
-  title g.render(ti, [expand: ['identifiers', 'type', 'subType', 'tags'], excludes: ['entitlements', 'coverage', 'work', 'platformInstances', 'suppressFromDiscovery']])
+  title g.render(ti, [expand: ['identifiers', 'type', 'subType', 'tags'], excludes: ['entitlements', 'coverage', 'work', 'platformInstances']])
 
 }
 


### PR DESCRIPTION
removed 'suppressFromDiscovery' from excludes section of the title render in exportEntry.