### PR TITLE
ERM-1083: Ensure that Entitlements that are not related to an internal KB resource cannot have custom coverage saved

### DIFF
--- a/service/grails-app/domain/org/olf/erm/Entitlement.groovy
+++ b/service/grails-app/domain/org/olf/erm/Entitlement.groovy
@@ -290,7 +290,11 @@ public class Entitlement implements MultiTenant<Entitlement>, Clonable<Entitleme
     this.type = this.type?.toLowerCase()
     this.authority = this.authority?.toUpperCase()
     
-    if (this.type == 'external') {
+    /* 
+     * Type 'internal' can be explicitly sent, or implicitly defined as no type being sent.
+     * Either way we want to remove any coverage before attempting to validate.
+     */
+    if (this.type != 'internal' && this.type != null) {
       // Clear the coverage.
       this.coverage?.clear()
     }


### PR DESCRIPTION
Changed beforeValidate to check 'not internal' rather than 'is external'.

This approach taken to expand on existing behaviour now we have more than two types.