### PR TITLE
ERM-986: Update data import process to handle new publicationType property.

### DIFF
--- a/service/grails-app/services/org/olf/ImportService.groovy
+++ b/service/grails-app/services/org/olf/ImportService.groovy
@@ -291,6 +291,10 @@ class ImportService implements DataBinder {
           coverageDepth: getFieldFromLine(currentRecord, acceptedFields, 'coverageDepth'),
           coverageNote: getFieldFromLine(currentRecord, acceptedFields, 'coverageNote'),
           instanceMedia: getFieldFromLine(currentRecord, acceptedFields, 'instanceMedia'),
+
+          // Pub Type should be populated with same data as Type for KBART
+          instancePublicationMedia: getFieldFromLine(currentRecord, acceptedFields, 'instanceMedia'),
+          
           instanceMedium: "electronic",
 
           dateMonographPublished: getFieldFromLine(currentRecord, acceptedFields, 'dateMonographPublished'),

--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -293,17 +293,17 @@ class PackageIngestService implements DataBinder {
                 }
               }
               else {
-                String message = "Skipping ${pc.title}. Unable to identify platform from ${platform_url_to_use} and ${pc.platformName}"
+                String message = "Skipping \"${pc.title}\". Unable to identify platform from ${platform_url_to_use} and ${pc.platformName}"
                 log.error(message)
               }
             }
             else {
-              String message = "Skipping ${pc.title}. Unable to resolve title from ${pc.title} with identifiers ${pc.instanceIdentifiers}"
+              String message = "Skipping \"${pc.title}\". Unable to resolve title from ${pc.title} with identifiers ${pc.instanceIdentifiers}"
               log.error(message)
             }
           }
         } catch ( Exception e ) {
-          String message = "Skipping ${pc.title}. System error: ${e.message}"
+          String message = "Skipping \"${pc.title}\". System error: ${e.message}"
           log.error(message,e)
         }
         result.titleCount++

--- a/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
+++ b/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
@@ -274,8 +274,8 @@ class TitleInstanceResolverService implements DataBinder{
         io_record.save(flush:true, failOnError:true)
       }
     }
-    else { 
-      log.debug("Create title failed validation checks - insufficient data to create a title record");
+    else {
+      log.error("Create title failed validation checks - insufficient data to create a title record");
       // We will return null, which means no title
       // throw new RuntimeException("Insufficient detail to create title instance record");
     }

--- a/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
+++ b/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
@@ -252,6 +252,7 @@ class TitleInstanceResolverService implements DataBinder{
         result.subTypeFromString = medium
       }
       
+      //TODO Remove this block (and same below)
       if ((resource_type?.length() ?: 0) > 0) {
         result.publicationTypeFromString = resource_type
         switch(resource_type) {

--- a/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
+++ b/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
@@ -313,13 +313,19 @@ class TitleInstanceResolverService implements DataBinder{
         title.name = citation.title
       }
 
+      /*
+       * For some reason whenever a title is updated with just refdata fields it fails to properly mark as dirty.
+       * The below solution of '.markDirty()' is not ideal, but it does solve the problem for now.
+      */
       if (title.publicationType.value != citation.instancePublicationMedia) {
         title.publicationTypeFromString = citation.instancePublicationMedia
+        title.markDirty()
       }
 
       if (validateCitationType(citation)) {
         if (title.type.value != citation.instanceMedia ) {
           title.typeFromString = citation.instanceMedia
+          title.markDirty()
         }
       } else {
         log.error("Type (${citation.instanceMedia}) does not match 'serial' or 'monograph' for title \"${citation.title}\", skipping field enrichment.")

--- a/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
+++ b/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
@@ -249,40 +249,15 @@ class TitleInstanceResolverService implements DataBinder{
 
         work: work
       )
+
+      // We can trust these by the check above for file imports and through logic in the adapters to set pubType and type correctly
+      result.typeFromString = resource_type
+      result.publicationTypeFromString = resource_pub_type
       
       if ((medium?.length() ?: 0) > 0) {
         result.subTypeFromString = medium
       }
       
-      //TODO Remove this block (and same below)
-      if ((resource_type?.length() ?: 0) > 0) {
-        result.publicationTypeFromString = resource_pub_type
-        switch(resource_type) {
-          case 'book':
-            result.typeFromString = 'monograph'
-            break
-          case 'journal':
-            result.typeFromString = 'serial'
-            break
-          case 'monograph':
-            result.typeFromString = 'monograph'
-            break
-          case 'serial':
-            result.typeFromString = 'serial'
-            break
-          default:
-            /**
-            ERM-987: ... check for the existence of a coverage statement.
-            If a coverage statement exists then type == "serial", otherwise "monograph"
-            **/
-            if ( resource_coverage ) {
-              result.typeFromString = 'serial'
-            } else {
-              result.typeFromString = 'monograph'
-            }
-        }
-      }
-
       result.save(flush:true, failOnError:true)
 
       // Iterate over all idenifiers in the citation and add them to the title record. We manually create the identifier occurrence 
@@ -321,36 +296,16 @@ class TitleInstanceResolverService implements DataBinder{
     if (trustedSourceTI == true) {
       log.debug("Trusted source for TI enrichment--enriching")
 
-      if (title.publicationType.value != citation.instanceMedia) {
-        title.publicationTypeFromString = citation.instancePublicationMedia
-        switch(citation.instanceMedia) {
-          case 'book':
-            title.typeFromString = 'monograph'
-            break
-          case 'journal':
-            title.typeFromString = 'serial'
-            break
-          case 'monograph':
-            title.typeFromString = 'monograph'
-            break
-          case 'serial':
-            title.typeFromString = 'serial'
-            break
-          default:
-            /**
-            ERM-987: ... check for the existence of a coverage statement.
-            If a coverage statement exists then type == "serial", otherwise "monograph"
-            **/
-            if ( citation.coverage ) {
-              title.typeFromString = 'serial'
-            } else {
-              title.typeFromString = 'monograph'
-            }
-        }
-      }
-
       if (title.name != citation.title) {
         title.name = citation.title
+      }
+
+      if (title.publicationType.value != citation.instancePublicationMedia) {
+        title.publicationTypeFromString = citation.instancePublicationMedia
+      }
+
+      if (title.type.value != citation.instanceMedia) {
+        title.typeFromString = citation.instanceMedia
       }
 
       if (title.dateMonographPublished != citation.dateMonographPublished) {

--- a/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
+++ b/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
@@ -166,7 +166,8 @@ class TitleInstanceResolverService implements DataBinder{
         bindData (sibling_citation, [
           "title": citation.title,
           "instanceMedium": "print",
-          "instanceMedia": (id.namespace.toLowerCase() == 'issn') ? "journal" : "book",
+          "instanceMedia": (id.namespace.toLowerCase() == 'issn') ? "serial" : "monograph",
+          "instancePublicationMedia": citation.instancePublicationMedia,
           "instanceIdentifiers": [
             [
               "namespace": id.namespace.toLowerCase(),
@@ -235,6 +236,7 @@ class TitleInstanceResolverService implements DataBinder{
 
       // Journal or Book etc
       def resource_type = citation.instanceMedia?.trim()
+      def resource_pub_type = citation.instancePublicationMedia?.trim()
       def resource_coverage = citation?.coverage
       result = new TitleInstance(
         name: citation.title,
@@ -254,7 +256,7 @@ class TitleInstanceResolverService implements DataBinder{
       
       //TODO Remove this block (and same below)
       if ((resource_type?.length() ?: 0) > 0) {
-        result.publicationTypeFromString = resource_type
+        result.publicationTypeFromString = resource_pub_type
         switch(resource_type) {
           case 'book':
             result.typeFromString = 'monograph'
@@ -320,7 +322,7 @@ class TitleInstanceResolverService implements DataBinder{
       log.debug("Trusted source for TI enrichment--enriching")
 
       if (title.publicationType.value != citation.instanceMedia) {
-        title.publicationTypeFromString = citation.instanceMedia
+        title.publicationTypeFromString = citation.instancePublicationMedia
         switch(citation.instanceMedia) {
           case 'book':
             title.typeFromString = 'monograph'

--- a/service/src/main/groovy/org/olf/dataimport/erm/ContentItem.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/erm/ContentItem.groovy
@@ -66,6 +66,11 @@ class ContentItem implements ContentItemSchema, Validateable {
   public String getInstanceMedia() {
     platformTitleInstance?.titleInstance?.type
   }
+
+  @Override
+  public String getInstancePublicationMedia() {
+    platformTitleInstance?.titleInstance?.publicationType
+  }
   
   private static final Map<String,List<String>> known_id_types = [
     electronic : ['EISSN', 'DOI', 'EZB'],

--- a/service/src/main/groovy/org/olf/dataimport/erm/TitleInstance.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/erm/TitleInstance.groovy
@@ -11,7 +11,7 @@ import groovy.transform.ToString
 class TitleInstance implements Validateable {
   String name
   Set<Identifier> identifiers
-  String type = 'journal'
+  String type = 'serial'
   String publicationType = 'journal'
   String subType = 'electronic'
 

--- a/service/src/main/groovy/org/olf/dataimport/erm/TitleInstance.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/erm/TitleInstance.groovy
@@ -12,6 +12,7 @@ class TitleInstance implements Validateable {
   String name
   Set<Identifier> identifiers
   String type = 'journal'
+  String publicationType = 'journal'
   String subType = 'electronic'
 
   String dateMonographPublished
@@ -22,6 +23,9 @@ class TitleInstance implements Validateable {
   
   String getType () {
     this.type?.toLowerCase()
+  }
+  String getPublicationType () {
+    this.publicationType?.toLowerCase()
   }
   String getSubType () {
     this.subType?.toLowerCase()

--- a/service/src/main/groovy/org/olf/dataimport/internal/PackageContentImpl.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/PackageContentImpl.groovy
@@ -20,6 +20,7 @@ class PackageContentImpl implements ContentItemSchema, Validateable {
   String title
   String instanceMedium
   String instanceMedia
+  String instancePublicationMedia
   String sourceIdentifier
   String embargo
   String coverageDepth

--- a/service/src/main/groovy/org/olf/dataimport/internal/PackageSchema.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/PackageSchema.groovy
@@ -94,6 +94,7 @@ interface PackageSchema extends Validateable {
     String getTitle()
     String getInstanceMedium()
     String getInstanceMedia()
+    String getInstancePublicationMedia()
     Collection<IdentifierSchema> getInstanceIdentifiers()
     Collection<IdentifierSchema> getSiblingInstanceIdentifiers()
     Collection<CoverageStatementSchema> getCoverage()

--- a/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
+++ b/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
@@ -211,9 +211,11 @@ public class GOKbOAIAdapter implements KBCacheUpdater, DataBinder {
           def tipp_media = null
 
           // It appears that tipp_entry?.title?.type?.value() can be a list
-          String title_type = tipp_entry?.title?.type?.text()
+          String title_pub_type = tipp_entry?.title?.type?.text()
+          // Turns JournalInstance into journal, BookInstance into book, DatabaseInstance into database
+          String tipp_pub_media = title_pub_type.toLowerCase().replace('Instance', '')
 
-          switch ( title_type ) {
+          switch ( title_pub_type ) {
             case 'JournalInstance':
               tipp_media = 'journal'
               break
@@ -306,7 +308,6 @@ public class GOKbOAIAdapter implements KBCacheUpdater, DataBinder {
     if (binding?.hasErrors()) {
       binding.allErrors.each { log.debug "\t${it}" }
     }
-
     pkg
   }
 

--- a/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
+++ b/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
@@ -280,6 +280,7 @@ public class GOKbOAIAdapter implements KBCacheUpdater, DataBinder {
             "title": tipp_title,
             "instanceMedium": tipp_medium,
             "instanceMedia": tipp_media,
+            "instancePublicationMedia": "TEST",
             "sourceIdentifier": title_source_identifier,
             "instanceIdentifiers": tipp_instance_identifiers,
             "siblingInstanceIdentifiers": tipp_sibling_identifiers,

--- a/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
+++ b/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
@@ -210,28 +210,6 @@ public class GOKbOAIAdapter implements KBCacheUpdater, DataBinder {
           def tipp_medium = tipp_entry?.medium?.text()
           def tipp_media = null
 
-          // It appears that tipp_entry?.title?.type?.value() can be a list
-          String title_pub_type = tipp_entry?.title?.type?.text()
-          // Turns JournalInstance into journal, BookInstance into book, DatabaseInstance into database
-          String tipp_pub_media = title_pub_type.toLowerCase().replace('Instance', '')
-
-          switch ( title_pub_type ) {
-            case 'JournalInstance':
-              tipp_media = 'journal'
-              break
-            case 'BookInstance':
-              tipp_media = 'book'
-              break
-            case 'DatabaseInstance':
-              tipp_media = 'database'
-              break
-            case 'OtherInstance':
-              tipp_media = 'other'
-              break
-            default:
-              tipp_media = 'journal'
-              break
-          }
           def tipp_instance_identifiers = [] // [ "namespace": "issn", "value": "0278-7393" ]
           def tipp_sibling_identifiers = []
 
@@ -260,6 +238,28 @@ public class GOKbOAIAdapter implements KBCacheUpdater, DataBinder {
 
           def tipp_coverage_depth = tipp_entry.coverage.@coverageDepth?.toString()
           def tipp_coverage_note = tipp_entry.coverage.@coverageNote?.toString()
+
+          // It appears that tipp_entry?.title?.type?.value() can be a list
+          String title_pub_type = tipp_entry?.title?.type?.text()
+          // Turns JournalInstance into journal, BookInstance into book, DatabaseInstance into database
+          String tipp_pub_media = title_pub_type.toLowerCase().replace('Instance', '')
+
+          switch ( title_pub_type ) {
+            case 'JournalInstance':
+              tipp_media = 'serial'
+              break
+            case 'BookInstance':
+              tipp_media = 'monograph'
+              break
+            default:
+              if ( tipp_coverage ) {
+                tipp_media = 'serial'
+              } else {
+                tipp_media = 'monograph'
+              }
+              break
+          }
+
           final String embargo = tipp_entry.coverage?.@embargo?.toString()
 
           def tipp_url = tipp_entry.url?.text()
@@ -282,7 +282,7 @@ public class GOKbOAIAdapter implements KBCacheUpdater, DataBinder {
             "title": tipp_title,
             "instanceMedium": tipp_medium,
             "instanceMedia": tipp_media,
-            "instancePublicationMedia": "TEST",
+            "instancePublicationMedia": tipp_pub_media,
             "sourceIdentifier": title_source_identifier,
             "instanceIdentifiers": tipp_instance_identifiers,
             "siblingInstanceIdentifiers": tipp_sibling_identifiers,

--- a/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
+++ b/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
@@ -242,7 +242,7 @@ public class GOKbOAIAdapter implements KBCacheUpdater, DataBinder {
           // It appears that tipp_entry?.title?.type?.value() can be a list
           String title_pub_type = tipp_entry?.title?.type?.text()
           // Turns JournalInstance into journal, BookInstance into book, DatabaseInstance into database
-          String tipp_pub_media = title_pub_type.replace('Instance', '').toLowerCase()
+          String tipp_pub_media = title_pub_type.replace('Instance', '')
 
           switch ( title_pub_type ) {
             case 'JournalInstance':

--- a/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
+++ b/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
@@ -242,7 +242,7 @@ public class GOKbOAIAdapter implements KBCacheUpdater, DataBinder {
           // It appears that tipp_entry?.title?.type?.value() can be a list
           String title_pub_type = tipp_entry?.title?.type?.text()
           // Turns JournalInstance into journal, BookInstance into book, DatabaseInstance into database
-          String tipp_pub_media = title_pub_type.toLowerCase().replace('Instance', '')
+          String tipp_pub_media = title_pub_type.replace('Instance', '').toLowerCase()
 
           switch ( title_pub_type ) {
             case 'JournalInstance':


### PR DESCRIPTION
This also references ERM-987.

Moved a bunch of code around--most notably the logic which "guesses" the type from import, which is now in adapter. Anything coming in through internal routes (Import/KBART import) should already have a valid type--if it doesn't it gets rejected.
A few other tweaks, including one to fix the behaviour of the enrichment process... refdata fields did not seem to dirty the title, causing failure to save unless alongside a String field. (Workaround now in place), and some error message tweaks as well.