### PR TITLE
ERM-1140: KBART export omits column headers/field names

### DIFF
--- a/service/src/main/groovy/org/olf/export/KBart.groovy
+++ b/service/src/main/groovy/org/olf/export/KBart.groovy
@@ -185,7 +185,7 @@ public class KBart implements Serializable {
   static String[] header() {
     List<String> header = new ArrayList<String>()
     KBart.class.getDeclaredFields().each {
-      if (it.modifiers == java.lang.reflect.Modifier.PUBLIC) {
+      if (it.modifiers == java.lang.reflect.Modifier.PRIVATE) {
         header.add(it.name)
       }
     }


### PR DESCRIPTION
see my comment on the issue: https://issues.folio.org/browse/ERM-1140