### PR TITLE
ERM-1533: Agreement start and end dates should be the earliest period start and latest period end date respectively

### DIFF
--- a/service/grails-app/controllers/org/olf/AdminController.groovy
+++ b/service/grails-app/controllers/org/olf/AdminController.groovy
@@ -91,7 +91,10 @@ class AdminController implements DataBinder{
   }
 
   public triggerHousekeeping() {
+    def result = [:]
     ermHousekeepingService.triggerHousekeeping()
+    result.status = 'OK'
+    render result as JSON
   }
 
   public triggerEntitlementLogUpdate() {

--- a/service/grails-app/migrations/update-mod-agreements-3-1.groovy
+++ b/service/grails-app/migrations/update-mod-agreements-3-1.groovy
@@ -157,4 +157,13 @@ databaseChangeLog = {
       confirm: "Successfully updated the ti_first_editor column."
     )
   }
+
+  changeSet(author: "efreestone (manual)", id: "202101211152-001") {
+    addColumn (tableName: "subscription_agreement" ) {
+      column(name: "sa_start_date", type: "timestamp")
+    }
+    addColumn (tableName: "subscription_agreement" ) {
+      column(name: "sa_end_date", type: "timestamp")
+    }
+  }
 }

--- a/service/grails-app/services/org/olf/ErmHousekeepingService.groovy
+++ b/service/grails-app/services/org/olf/ErmHousekeepingService.groovy
@@ -9,9 +9,16 @@ import grails.gorm.transactions.Transactional
 public class ErmHousekeepingService {
 
   def coverageService
+  def entitlementLogService
+  def subscriptionAgreementCleanupService
 
   public void triggerHousekeeping() {
     // An administrative process - attempt to coalesce any rogue coverage statements
-    coverageService.coalesceCoverageStatements();
+    //TODO UNCOMMENT THIS
+    /* coverageService.coalesceCoverageStatements();
+    entitlementLogService.triggerUpdate(); */
+
+    // A process to ensure the correct start/end date is stored per agreement
+    subscriptionAgreementCleanupService.triggerDateCleanup();
   }
 }

--- a/service/grails-app/services/org/olf/ErmHousekeepingService.groovy
+++ b/service/grails-app/services/org/olf/ErmHousekeepingService.groovy
@@ -14,9 +14,8 @@ public class ErmHousekeepingService {
 
   public void triggerHousekeeping() {
     // An administrative process - attempt to coalesce any rogue coverage statements
-    //TODO UNCOMMENT THIS
-    /* coverageService.coalesceCoverageStatements();
-    entitlementLogService.triggerUpdate(); */
+    coverageService.coalesceCoverageStatements();
+    entitlementLogService.triggerUpdate();
 
     // A process to ensure the correct start/end date is stored per agreement
     subscriptionAgreementCleanupService.triggerDateCleanup();

--- a/service/grails-app/services/org/olf/PeriodService.groovy
+++ b/service/grails-app/services/org/olf/PeriodService.groovy
@@ -1,0 +1,32 @@
+package org.olf
+
+import java.time.LocalDate
+import org.olf.erm.Period;
+
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class PeriodService {
+
+  public static LocalDate calculateStartDate (Set<Period> periods) {
+    LocalDate earliest = null
+    for (def p : periods) {
+      if (earliest == null || p.startDate < earliest) earliest = p.startDate
+    }
+    earliest
+  }
+
+  public static LocalDate calculateEndDate (Set<Period> periods) {
+     LocalDate latest = null
+    // Use for loop to allow us to break out if we find open ended period
+    for (def p : periods) {
+      if(p.endDate == null) {
+        latest = null
+        break
+      } else if (latest == null || p.endDate > latest) {
+        latest = p.endDate
+      }
+    }
+    latest
+  }
+}

--- a/service/grails-app/services/org/olf/SubscriptionAgreementCleanupService.groovy
+++ b/service/grails-app/services/org/olf/SubscriptionAgreementCleanupService.groovy
@@ -1,0 +1,68 @@
+package org.olf
+
+import java.time.LocalDate
+
+import org.olf.erm.SubscriptionAgreement;
+import org.olf.erm.Period;
+
+import groovy.transform.CompileDynamic
+
+@CompileDynamic
+class SubscriptionAgreementCleanupService {
+  def periodService
+
+  private List<List<String>> batchFetchAgreements(final int agreementBatchSize, int agreementBatchCount) {
+    // Fetch the ids and localCodes for all platforms
+    List<List<String>> agreements = SubscriptionAgreement.createCriteria().list ([max: agreementBatchSize, offset: agreementBatchSize * agreementBatchCount]) {
+      order 'id'
+      projections {
+        property('id')
+        property('startDate')
+        property('endDate')
+      }
+    }
+    return agreements
+  }
+
+  private Set<Period> fetchPeriodsForAgreementId(String aggId) {
+    Set<Period> periods = Period.executeQuery("""
+      SELECT p FROM Period p
+      WHERE p.owner.id = :aggId
+      """,
+      [aggId: aggId]
+    )
+    return periods
+  }
+
+  void triggerDateCleanup() {
+    final int agreementBatchSize = 25
+    int agreementBatchCount = 0
+    SubscriptionAgreement.withNewTransaction {
+      List<List<String>> agreements = batchFetchAgreements(agreementBatchSize, agreementBatchCount)
+      while (agreements && agreements.size() > 0) {
+        SubscriptionAgreement.withNewSession { session ->
+          agreementBatchCount++
+          agreements.each { a ->
+            Set<Period> periods = fetchPeriodsForAgreementId(a[0])
+            LocalDate earliest = periodService.calculateStartDate(periods)
+            LocalDate latest = periodService.calculateEndDate(periods)
+            
+            if (a[1] != earliest || a[2] != latest) {
+              log.warn("Agreement date mismatch for (${a[0]}), calculating new start and end dates")
+              // Only actually fetch object if you have to
+              SubscriptionAgreement agg = SubscriptionAgreement.get(a[0])
+              agg.startDate = earliest
+              agg.endDate = latest
+              agg.save(failOnError: true)
+            }
+          }
+          
+          // Next page
+          agreements = batchFetchAgreements(agreementBatchSize, agreementBatchCount)
+          session.flush()
+          session.clear()
+        }
+      }
+    }
+  }
+}

--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -419,11 +419,15 @@
           "pathPattern": "/erm/sts/template/{id}",
           "permissionsRequired": ["erm.sts.collection.get"]
         },
-
         {
           "methods": ["GET"],
           "pathPattern": "/erm/entitlementLogEntry",
           "permissionsRequired": ["erm.entitlements.collection.get"]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/erm/admin/*",
+          "permissionsRequired": ["erm.admin.action"]
         }
       ]
     },{
@@ -463,7 +467,7 @@
         {
           "permissionsRequired" : [],
           "methods": [ "GET" ],
-          "pathPattern": "/erm/admin/triggerEntitlementLogUpdate",
+          "pathPattern": "/erm/admin/triggerHousekeeping",
           "unit": "hour",
           "delay": "24" 
         },
@@ -1092,6 +1096,11 @@
       "permissionName": "erm.sts.template",
       "displayName": "String templates perform template",
       "description": "Performs string templating"
+    },
+    {
+      "permissionName": "erm.admin.action",
+      "displayName": "Admin endpoint perform action",
+      "description": "Performs action from admin endpoint"
     }
   ],
   "launchDescriptor": {


### PR DESCRIPTION
Agreement start/end dates now saved to db - refs ERM-1532
OnValidate they are recalculated to be the earliest period start and latet period end, respectively
ERM admin endpoint now exposed, with new perm `erm.admin.action`.
Housekeeping task replaces old entitlement log update timer task. Now 3 housekeeping tasks will run on a 24 hour basis, including the entitlement log timer task and the new date cleanup task
Date cleanup task will fetch agreements, and compare their stored start/end dates to the periods. Discrepancies are then fixed. (This replaces a traditional migration between versions--allows for sweeping up of invalid data on a daily basis, so Agreement dates should never get out of date for more than a day)