### PR TITLE
Feature/tenant name mdc

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -145,8 +145,8 @@ dependencies {
   compile 'commons-io:commons-io:2.6'
 
   compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'     // TODO: Migrate away from this resource.
-  compile 'com.k_int.grails:web-toolkit-ce:5.0.0'
-  compile 'com.k_int.okapi:grails-okapi:4.0.0-rc.1'
+  compile 'com.k_int.grails:web-toolkit-ce:5.1.0'
+  compile 'com.k_int.okapi:grails-okapi:4.0.0'
 
   compile 'uk.co.cacoethes:groovy-handlebars-engine:0.2'
   compile 'com.github.jknack:handlebars-helpers:2.0.0'

--- a/service/grails-app/conf/logback.groovy
+++ b/service/grails-app/conf/logback.groovy
@@ -20,6 +20,7 @@ appender('STDOUT', ConsoleAppender) {
 
         pattern =
                 '%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} ' + // Date
+                        '[%X{tenant:-_NO_TENANT_}] ' + // Tenant
                         '%clr(%5p) ' + // Log level
                         '%clr(---){faint} %clr([%15.15t]){faint} ' + // Thread
                         '%clr(%-40.40logger{39}){cyan} %clr(:){faint} ' + // Logger

--- a/service/grails-app/services/org/olf/ImportService.groovy
+++ b/service/grails-app/services/org/olf/ImportService.groovy
@@ -13,11 +13,11 @@ import org.olf.dataimport.internal.HeaderImpl
 import org.olf.dataimport.internal.InternalPackageImpl
 import org.olf.dataimport.internal.PackageContentImpl
 import org.olf.dataimport.internal.PackageSchema
-import org.slf4j.MDC
 import org.springframework.context.MessageSource
 import org.springframework.context.i18n.LocaleContextHolder
 import org.springframework.validation.ObjectError
 
+import com.k_int.web.toolkit.mdc.TrackingMdcWrapper
 import com.opencsv.CSVReader
 
 import grails.web.databinding.DataBinder
@@ -27,6 +27,7 @@ import groovy.util.logging.Slf4j
 @CompileStatic
 @Slf4j
 class ImportService implements DataBinder {
+  private static final TrackingMdcWrapper MDC = new TrackingMdcWrapper()
   
   PackageIngestService packageIngestService
   

--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -12,7 +12,8 @@ import org.olf.kb.Platform
 import org.olf.kb.PlatformTitleInstance
 import org.olf.kb.RemoteKB
 import org.olf.kb.TitleInstance
-import org.slf4j.MDC
+
+import com.k_int.web.toolkit.mdc.TrackingMdcWrapper
 
 import grails.util.GrailsNameUtils
 import grails.web.databinding.DataBinder
@@ -23,6 +24,7 @@ import groovy.util.logging.Slf4j
  */
 @Slf4j
 class PackageIngestService implements DataBinder {
+  private static final TrackingMdcWrapper MDC = new TrackingMdcWrapper()
 
   // This boolean controls the behaviour of the loader when we encounter a title that does not have
   // a platform URL. We can error the row and do nothing, or create a row and point it at a proxy

--- a/service/grails-app/services/org/olf/general/jobs/JobRunnerService.groovy
+++ b/service/grails-app/services/org/olf/general/jobs/JobRunnerService.groovy
@@ -184,7 +184,7 @@ class JobRunnerService implements EventPublisher {
       work = { final String tid, final String jid, final Runnable wrk ->
           Tenants.withId(tid) {
             try {
-              MDC.setContextMap( jobId: "${jid}", tenantId: "${tid}" )
+              MDC.setContextMap( jobId: "${jid}", tenantId: "${tid}", tenant: OkapiTenantResolver.schemaNameToTenantId(tid) )
               JobContext.current.set(new JobContext( jobId: jid, tenantId: tid ))
               beginJob(jid)
               wrk()

--- a/service/grails-app/services/org/olf/general/jobs/JobRunnerService.groovy
+++ b/service/grails-app/services/org/olf/general/jobs/JobRunnerService.groovy
@@ -18,10 +18,10 @@ import org.olf.CoverageService
 import org.olf.DocumentAttachmentService
 import org.olf.ImportService
 import org.olf.KbHarvestService
-import org.slf4j.MDC
 
 import com.k_int.okapi.OkapiTenantAdminService
 import com.k_int.okapi.OkapiTenantResolver
+import com.k_int.web.toolkit.mdc.TrackingMdcWrapper
 import com.k_int.web.toolkit.refdata.RefdataValue
 
 import grails.events.EventPublisher
@@ -31,6 +31,7 @@ import groovy.util.logging.Slf4j
 
 @Slf4j
 class JobRunnerService implements EventPublisher {
+  private static final TrackingMdcWrapper MDC = new TrackingMdcWrapper()
   
   // Any auto injected beans here can be accessed within the `work` runnable
   // of the job itself.

--- a/service/grails-app/views/object/_object.gson
+++ b/service/grails-app/views/object/_object.gson
@@ -41,7 +41,6 @@ if ( object instanceof String ) {
     out << JsonOutput.toJson(object)
   } else {
     // Use the built in rendering.
-    System.out.println "Attempting to render type: ${object.class}"
     json g.render (object)
   }
 }


### PR DESCRIPTION
Adds "tenant" MDC variable that contains the tenant name as OKAPI understands it (i.e. not our internal schema name), and then outputs it when present in the log statements.