### PR TITLE
FOLIO-3131: Use https for maven.k-int.com

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -2,7 +2,7 @@ buildscript {
   repositories {
     jcenter()
     maven { url "https://repo.grails.org/grails/core" }
-//    maven { url "http://maven.k-int.com/content/repositories/releases" }
+//    maven { url "https://maven.k-int.com/content/repositories/releases" }
   }
   dependencies {
     classpath "org.grails:grails-gradle-plugin:$grailsVersion"
@@ -43,7 +43,7 @@ repositories {
   jcenter()
   maven { url 'https://repo.grails.org/grails/core' }
   maven { url 'https://maven.indexdata.com/' }
-  maven { url "http://maven.k-int.com/content/repositories/releases" }
+  maven { url "https://maven.k-int.com/content/repositories/releases" }
 }
 
 sourceSets {


### PR DESCRIPTION
Replace http by https for maven.k-int.com, fixing MitM vulnerability.

Unencrypted http allows an attacker to run a
Machine-in-the-Middle (MitM) attack that replaces
the content downloaded during the build by malware.

Such attacks against unencrypted maven repositories are well-known since 2019:
https://github.com/github/securitylab/issues/21

For this reason maven disabled unencrypted http by default since 2021:
https://maven.apache.org/docs/3.8.1/release-notes.html#cve-2021-26291