### PR TITLE
Change editStatus logic on harvesting from GOKb

### DIFF
--- a/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
+++ b/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
@@ -147,8 +147,8 @@ public class GOKbOAIAdapter extends WebSourceAdapter implements KBCacheUpdater, 
         // ToDo: Decide what to do about deleted records
       }
       else {
-        if (editStatus.toLowerCase() != 'approved') {
-          log.info("Ignoring Package '${package_name}' because editStatus=='${editStatus}' (required: 'approved')")
+        if (editStatus.toLowerCase() == 'rejected') {
+          log.info("Ignoring Package '${package_name}' because editStatus=='${editStatus}'")
         } else if (listStatus.toLowerCase() != 'checked') {
           log.info("Ignoring Package '${package_name}' because listStatus=='${listStatus}' (required: 'checked')")
         } else {


### PR DESCRIPTION
Feedback from GOKb indicates that only packages with editStatus == rejected should be skipped during harvesting and that other statuses (approved, in-progress) should be treated as good to harvest