### PR TITLE
fix: ERM-1781

### DIFF
--- a/service/grails-app/domain/org/olf/kb/ErmResource.groovy
+++ b/service/grails-app/domain/org/olf/kb/ErmResource.groovy
@@ -71,7 +71,10 @@ public class ErmResource extends ErmTitleList implements MultiTenant<ErmResource
   def beforeValidate() {
     if (!validating) {
       validating = true
-      CoverageService.changeListener(this)
+      // Attempt to avoid session locking
+      ErmResource.withSession {
+        CoverageService.changeListener(this)
+      }
       validating = false
     }
   }


### PR DESCRIPTION
Error on adding coverage to PCI which overlaps with existing coverage on PTI/TI, validate now uses existing session