### PR TITLE
feat: ERM-1774 Regularly remove organizations that do not have any links to Agreements/Packages

### DIFF
--- a/service/grails-app/services/org/olf/ErmHousekeepingService.groovy
+++ b/service/grails-app/services/org/olf/ErmHousekeepingService.groovy
@@ -18,6 +18,9 @@ public class ErmHousekeepingService {
 
     // A process to ensure the correct start/end date is stored per agreement
     subscriptionAgreementCleanupService.triggerDateCleanup();
+
+    // A process to ensure any unused Org records are deleted
+    subscriptionAgreementCleanupService.triggerOrgsCleanup();
     
     remoteKbCleanupService.checkLocal();
   }

--- a/service/grails-app/services/org/olf/SubscriptionAgreementCleanupService.groovy
+++ b/service/grails-app/services/org/olf/SubscriptionAgreementCleanupService.groovy
@@ -2,6 +2,8 @@ package org.olf
 
 import java.time.LocalDate
 
+import org.olf.general.Org;
+import org.olf.kb.Pkg;
 import org.olf.erm.SubscriptionAgreement;
 import org.olf.erm.Period;
 
@@ -71,5 +73,17 @@ class SubscriptionAgreementCleanupService {
         }
       }
     }
+  }
+
+  void triggerOrgsCleanup() {
+    Org.executeUpdate("""
+      DELETE from Org as theOrg WHERE NOT EXISTS (
+        FROM SubscriptionAgreementOrg as sao
+          WHERE sao.org = theOrg
+      ) AND NOT EXISTS (
+        FROM Pkg as p
+          WHERE p.vendor = theOrg
+      )
+    """)
   }
 }


### PR DESCRIPTION
Added triggerOrgsCleanup method to SubscriptionAgreementCleanupService, which will delete any Org records not in use either on a SubscriptionAgreementOrg or a Pkg