### PR TITLE
fix: ERM-1847

### DIFF
--- a/service/grails-app/services/org/olf/TitleIngestService.groovy
+++ b/service/grails-app/services/org/olf/TitleIngestService.groovy
@@ -62,7 +62,14 @@ class TitleIngestService implements DataBinder {
 
     // resolve may return null, used to throw exception which causes the whole package to be rejected. Needs
     // discussion to work out best way to handle.
-    TitleInstance title = titleInstanceResolverService.resolve(pc, trustedSourceTI)
+
+    // ERM-1847 Changed assert in TIRS to an explicit exception, which we can catch here. Should stop job from hanging on bad data
+    TitleInstance title;
+    try {
+      title = titleInstanceResolverService.resolve(pc, trustedSourceTI)
+    } catch (Exception e){
+      log.error("Error resolving title (${pc.title}), skipping ${e.message}")
+    }
 
     if (title != null) {
       /* ERM-1801

--- a/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
+++ b/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
@@ -527,7 +527,9 @@ class TitleInstanceResolverService implements DataBinder{
          */
         final List<Identifier> id_matches = Identifier.executeQuery('select id from Identifier as id where id.value = :value and id.ns.value = :ns',[value:id.value, ns:namespaceMapping(id.namespace)], [max:2])
 
-        assert ( id_matches.size() <= 1 )
+        if (id_matches.size() > 1) {
+          throw new RuntimeException("Multiple (${id_matches.size()}) class one matches found for identifier ${id.namespace}::${id.value}");
+        }
 
         // For each matched (It should only ever be 1)
         id_matches.each { matched_id ->


### PR DESCRIPTION
ERM-1847: Failure to resolve a title should lead to skipping title

Changed an assert to instead throw an exception, to stop job hanging

ERM-1847