### PR TITLE
fix: namespace mapping fix ERM-1649

### DIFF
--- a/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
+++ b/service/grails-app/services/org/olf/TitleInstanceResolverService.groovy
@@ -418,26 +418,6 @@ class TitleInstanceResolverService implements DataBinder{
              citation.instanceMedia.toLowerCase() == 'serial' )
   }
 
-  /**
-   * Given an identifier in a citation { value:'1234-5678', namespace:'isbn' } lookup or create an identifier in the DB to represent that info
-   */
-  private Identifier lookupOrCreateIdentifier(final String value, final String namespace) {
-    Identifier result = null;
-    def identifier_lookup = Identifier.executeQuery('select id from Identifier as id where id.value = :value and id.ns.value = :ns',[value:value, ns:namespace]);
-    switch(identifier_lookup.size() ) {
-      case 0:
-        IdentifierNamespace ns = lookupOrCreateIdentifierNamespace(namespace);
-        result = new Identifier(ns:ns, value:value).save(flush:true, failOnError:true);
-        break;
-      case 1:
-        result = identifier_lookup.get(0);
-        break;
-      default:
-        throw new RuntimeException("Matched multiple identifiers for ${id}");
-        break;
-    }
-    return result;
-  }
 
   // ERM-1649. This function acts as a way to manually map incoming namespaces onto known namespaces where we believe the extra information is unhelpful.
   // This is also the place to do any normalisation (lowercasing etc).
@@ -458,6 +438,30 @@ class TitleInstanceResolverService implements DataBinder{
     }
 
     result
+  }
+
+  /**
+   * Given an identifier in a citation { value:'1234-5678', namespace:'isbn' } lookup or create an identifier in the DB to represent that info
+   */
+  private Identifier lookupOrCreateIdentifier(final String value, final String namespace) {
+    Identifier result = null;
+
+    // Ensure we are looking up properly mapped namespace (pisbn -> isbn, etc)
+    def identifier_lookup = Identifier.executeQuery('select id from Identifier as id where id.value = :value and id.ns.value = :ns',[value:value, ns:namespaceMapping(namespace)]);
+
+    switch(identifier_lookup.size() ) {
+      case 0:
+        IdentifierNamespace ns = lookupOrCreateIdentifierNamespace(namespace);
+        result = new Identifier(ns:ns, value:value).save(flush:true, failOnError:true);
+        break;
+      case 1:
+        result = identifier_lookup.get(0);
+        break;
+      default:
+        throw new RuntimeException("Matched multiple identifiers for ${id}");
+        break;
+    }
+    return result;
   }
 
   /*


### PR DESCRIPTION
Namespace mapping was not occurring in a vital place, this has been rectified to stop us creating multiples of the same identifier (eissn AND issn for example) and then matching on them as if they were the same, giving us a double match and a failure.

ERM-1847 - This will stop the data problem which causes that crash. Separate work done to ensure no crash in this case in future