### PR TITLE
feat: Allow cloning supplementaryProperties

### DIFF
--- a/service/grails-app/controllers/org/olf/SubscriptionAgreementController.groovy
+++ b/service/grails-app/controllers/org/olf/SubscriptionAgreementController.groovy
@@ -565,7 +565,7 @@ class SubscriptionAgreementController extends OkapiTenantAwareController<Subscri
     'linkedLicenses': ['linkedLicenses', 'licenseNote'],
     'externalLicenses': ['externalLicenseDocs'],
     'organizations': ['orgs'],
-    'supplementaryInformation': ['supplementaryDocs'],
+    'supplementaryProperties': ['customProperties'],
     'usageData': ['usageDataProviders'],
 //    'tags': ['tags']
   ]

--- a/service/grails-app/domain/org/olf/erm/SubscriptionAgreement.groovy
+++ b/service/grails-app/domain/org/olf/erm/SubscriptionAgreement.groovy
@@ -34,7 +34,7 @@ public class SubscriptionAgreement extends ErmTitleList implements CustomPropert
     periods: { [new Period('owner': delegate, 'startDate': LocalDate.now())] },
     name: { "Copy of: ${owner.name}" /* Owner is the current object. */ }
   ]  
-  static copyByCloning = ['supplementaryDocs', 'docs', 'externalLicenseDocs']
+  static copyByCloning = ['customProperties', 'supplementaryDocs', 'docs', 'externalLicenseDocs']
   
   String description
   String id


### PR DESCRIPTION
customProperties now clonable with the key 'supplementaryProperties', and the key for 'supplementaryDocs' has been changed from 'supplementaryInformation' to 'supplementaryDocs' pending frontend work

ERM-1848