### PR TITLE
fix: ERM-1903

### DIFF
--- a/service/grails-app/views/entitlement/_entitlement.gson
+++ b/service/grails-app/views/entitlement/_entitlement.gson
@@ -6,23 +6,26 @@ import org.olf.erm.Entitlement
 
 @Field Entitlement entitlement
 
+def should_render_default_coverage = false
+
 if (entitlement.type == 'external') {
   json tmpl."externalEntitlement"(entitlement)
 } else {
   final def should_expand = ['poLines', 'resource', 'tags' ]
-  final def should_exclude = []
+  final def should_exclude = ['coverage']
   if ( controllerName != 'subscriptionAgreement' ) {
     should_expand << 'owner'
+    should_render_default_coverage = true
   }
   
   json g.render(entitlement, [expand: should_expand, excludes: should_exclude]) {
-        
+    
     if (entitlement.coverage) {
-      
+    
       'coverage' g.render (entitlement.coverage)
       'customCoverage' true
-       
-    } else if (entitlement?.resource?.coverage) {
+      
+    } else if (entitlement?.resource?.coverage && should_render_default_coverage) {
       'coverage' g.render (entitlement?.resource?.coverage)
       'customCoverage' false
       


### PR DESCRIPTION
On editing an agreement with an agreement line for a PCI, "custom coverage" incorrectly populated. We now only render default coverage as 'coverage' when not on the subscription agreement controller

ERM-1903