### PR TITLE
fix: Namespace mapping

### DIFF
--- a/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/IdFirstTIRSImpl.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/IdFirstTIRSImpl.groovy
@@ -268,7 +268,10 @@ class IdFirstTIRSImpl extends BaseTIRS implements DataBinder, TitleInstanceResol
         }
          * We have to know that eissn == issn etc... Use namespaceMapping function
          */
-        final List<Identifier> id_matches = Identifier.executeQuery('select id from Identifier as id where id.value = :value and id.ns.value = :ns',[value:id.value, ns:namespaceMapping(id.namespace)], [max:2])
+
+         // TODO we have the possibility for Kiwi that an existing TI is in place with namespace eissn, since cleanup is a complicated matter
+         // For the time being, allow matching BOTH of `eissn` to `issn` (As per the story), but also `issn` to `eissn` in our db
+        final List<Identifier> id_matches = Identifier.executeQuery('select id from Identifier as id where id.value = :value and (id.ns.value = :mns or id.ns.value = :ns)',[value:id.value, ns:id.namespace, mns:namespaceMapping(id.namespace)], [max:2])
 
         if (id_matches.size() > 1) {
           throw new RuntimeException("Multiple (${id_matches.size()}) class one matches found for identifier ${id.namespace}::${id.value}");


### PR DESCRIPTION
Changed match logic so that any title instances currently in system with identifiers of type eissn or pissn or the like are matchable against incoming versions of the identifier of type issn etc. Also added a comment to the effect that this is temporary, when we eventually have a fix for the databases we wouldn't expect to have to match against any eissn etc in the DB

ERM-1917