### PR TITLE
fix: Dropped resource duplication

### DIFF
--- a/service/grails-app/migrations/update-mod-agreements-5-1.groovy
+++ b/service/grails-app/migrations/update-mod-agreements-5-1.groovy
@@ -8,4 +8,32 @@ databaseChangeLog = {
       confirm: "Successfully updated the ent_content_updated column."
     )
   }
+
+  /* Adding some indexes with sights set on performance */
+
+  // Entitlement active to/from dates
+  changeSet(author: "efreestone (manual)", id: "20211119-1037-001") {
+    createIndex(indexName: "ent_active_to", tableName: "entitlement") {
+      column(name: "ent_active_to")
+      column(name: "ent_active_from")
+    }
+
+    createIndex(indexName: "ent_active_from", tableName: "entitlement") {
+      column(name: "ent_active_from")
+      column(name: "ent_active_to")
+    }
+  }
+
+  // PCI access start/end dates
+  changeSet(author: "efreestone (manual)", id: "20211119-1037-002") {
+    createIndex(indexName: "pci_access_start", tableName: "package_content_item") {
+      column(name: "pci_access_start")
+      column(name: "pci_access_end")
+    }
+
+    createIndex(indexName: "pci_access_end", tableName: "package_content_item") {
+      column(name: "pci_access_end")
+      column(name: "pci_access_start")
+    }
+  }
 }


### PR DESCRIPTION
Dropped resources are no longer duplicated in agreement line resource list (Also, future). However performance has taken a huge hit. In order to attempt to combat this, idexes ave been created, but they do not mitigate the effects enough, so this branch will remain in draft until a performance review

ERM-1904