### PR TITLE
fix: Sort agreement lines by name then reference then UUID in the UI

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -168,7 +168,7 @@ dependencies {
 
   // compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'     // TODO: Migrate away from this resource.
   // compile 'com.k_int.grails:web-toolkit-ce:5.3.0'
-  compile 'com.k_int.grails:web-toolkit-ce:6.0.2'
+  compile 'com.k_int.grails:web-toolkit-ce:6.0.3-rc.1'
   compile 'com.k_int.okapi:grails-okapi:4.1.2'
 
   compile 'uk.co.cacoethes:groovy-handlebars-engine:0.2'


### PR DESCRIPTION
Fix to update to latest version of web-toolkit. Fix was to remove caching of domainUtil properties... certain fields were being marked initially as "non-sortable" because they were first accessed through a non sortable property, such as "some.unsortable.property.something.child". Then when another process attempted to access "child", it would be marked as unsortable in the cache, stopping the sort. Caching has now been removed

ERM-1931