### PR TITLE
fix: MatchKey

### DIFF
--- a/service/grails-app/domain/org/olf/kb/MatchKey.groovy
+++ b/service/grails-app/domain/org/olf/kb/MatchKey.groovy
@@ -25,4 +25,8 @@ public class MatchKey implements MultiTenant<MatchKey> {
       key(nullable:false, blank:false)
     value(nullable:true, blank:false)
   }
+
+  String toString() {
+    "MatchKey:${id} (${key}: ${value}) on resource (${resource})"
+  }
 }

--- a/service/grails-app/services/org/olf/ErmResourceService.groovy
+++ b/service/grails-app/services/org/olf/ErmResourceService.groovy
@@ -1,5 +1,7 @@
 package org.olf
 
+import org.olf.dataimport.internal.PackageSchema.ContentItemSchema
+
 import org.olf.kb.ErmResource
 import org.olf.kb.TitleInstance
 import org.olf.kb.PlatformTitleInstance
@@ -11,6 +13,8 @@ import groovy.util.logging.Slf4j
 @Slf4j
 @CompileStatic
 public class ErmResourceService {
+  KbManagementService kbManagementService
+
   private final static String PCI_HQL = """
     SELECT id FROM PackageContentItem AS pci
     WHERE pci.pti.id = :resId
@@ -61,6 +65,27 @@ public class ErmResourceService {
     }
 
     resourceList
+  }
+
+
+  // FIXME do we actually want this?
+  // This method should take in an ErmResource and return a ContentItemSchema, which can then be used to create matchKeys
+  ContentItemSchema resourceToSchema(ErmResource resource) {
+
+  }
+
+  void addTiToQueue(ErmResource res) {
+    if (res instanceof TitleInstance) {
+      kbManagementService.addTiToQueue(res?.id)
+    }
+
+    if (res instanceof PlatformTitleInstance) {
+      kbManagementService.addTiToQueue(res?.titleInstance?.id)
+    }
+
+    if (res instanceof PackageContentItem) {
+      kbManagementService.addTiToQueue(res?.pti?.titleInstance?.id)
+    }
   }
 }
 

--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -186,13 +186,13 @@ class PackageIngestService implements DataBinder {
                   ).save(failOnError: true)
                   
                   // ERM-1799 Ensure initial matchKeyCreation
-                  matchKeyService.upsertMatchKeys(pti, matchKeys)
+                  matchKeyService.updateMatchKeys(pti, matchKeys)
                 } else if (trustedSourceTI) {
                   /*
                    * We may need to update the match key information
                    * from the incoming package for existing PTIs
                    */
-                  matchKeyService.upsertMatchKeys(pti, matchKeys)
+                  matchKeyService.updateMatchKeys(pti, matchKeys)
                 }
 
                 // Lookup or create a package content item record for this title on this platform in this package
@@ -214,7 +214,7 @@ class PackageIngestService implements DataBinder {
                   )
 
                   // ERM-1799, match keys need adding to PCI 
-                  matchKeyService.upsertMatchKeys(pci, matchKeys, false)
+                  matchKeyService.updateMatchKeys(pci, matchKeys, false)
                   isNew = true
                 }
                 else {
@@ -226,7 +226,7 @@ class PackageIngestService implements DataBinder {
                     * We may need to update the match key information
                     * from the incoming package for existing PCIs
                     */
-                    matchKeyService.upsertMatchKeys(pci, matchKeys, false)
+                    matchKeyService.updateMatchKeys(pci, matchKeys, false)
                   }
                 }
 


### PR DESCRIPTION
UpsertMatchKeys replaced with updateMatchKeys, which checks each match key on resource against incoming matchKeys, and can insert or remove those key/value pairs which are not equivalent. Also added a toString for MatchKeys, and updated eventHandler to kick off ResourceRematch when match keys change. This will cause ResourceRematch on TI creation.