### PR TITLE
fix: ERM-1800

### DIFF
--- a/service/grails-app/domain/org/olf/general/jobs/ResourceRematchJob.groovy
+++ b/service/grails-app/domain/org/olf/general/jobs/ResourceRematchJob.groovy
@@ -2,8 +2,17 @@ package org.olf.general.jobs
 
 import grails.gorm.MultiTenant
 import grails.gorm.multitenancy.Tenants
+
+import groovy.json.JsonSlurper
+
 import java.time.Instant
 
+
+/*
+ If this job contains a payload, we use that to rematch certain TIs.
+ Else we rely on the "since" variable to rematch on all TIs which have "changed" (for some definition of changed) since the timestamp
+ If neither exist, error out
+ */
 class ResourceRematchJob extends PersistentJob implements MultiTenant<ResourceRematchJob>{
   Instant since
 
@@ -11,8 +20,44 @@ class ResourceRematchJob extends PersistentJob implements MultiTenant<ResourceRe
     since column: 'since'
   }
 
-  final Closure work = {
-    log.info "Running Resource Rematch Job"
-    kbManagementService.runRematchProcess(since)
+  final Closure getWork() {
+    final JsonSlurper js = new JsonSlurper()
+
+    final Closure theWork = { final String eventId, final String tenantId ->
+      log.info "Running Resource Rematch Job"
+      PersistentJob.withTransaction {
+        // We should ensure the job is read into the current session.
+        // This closure will probably execute in a future session
+        // and we need to reread the event in.
+        final PersistentJob job = PersistentJob.read(eventId)
+        if (job.fileUpload) {
+          kbManagementService.rematchResourcesForTIs(js.parse( fileUploadService.getInputStreamFor(job.fileUpload.fileObject) ))
+        } else if (job.since) {
+          /*
+           * IMPORTANT this automatic rematch process is extremely non-performant,
+           * and also it will run on ALL tis after first creation, which is not ideal.
+           * For lotus release this will simply be disabled, returning immediately.
+           * SEE ALSO KbManagementService triggerRematch method
+           */
+          
+          //kbManagementService.runRematchProcess(since)
+        } else {
+          throw new RuntimeException("No TIs specified through payload or timestamp.")
+        }
+      }
+    }.curry( this.id )
+    
+    theWork
+  }
+
+  static constraints = {
+    since(nullable:true);
+	}
+
+  void beforeValidate() {
+    if (!this.name) {
+      // Set the name from the instant
+      this.name = "Resource rematch job ${Instant.now()}"
+    }
   }
 }

--- a/service/grails-app/services/org/olf/KbManagementService.groovy
+++ b/service/grails-app/services/org/olf/KbManagementService.groovy
@@ -93,8 +93,7 @@ class KbManagementService {
      * For lotus release this will simply be disabled, returning immediately.
      * SEE ALSO ResourceRematchJob getWork closure
      */
-    return
-
+    /* 
     // Look for jobs already queued or in progress
     ResourceRematchJob rematchJob = ResourceRematchJob.findByStatusInList([
       ResourceRematchJob.lookupStatus('Queued'),
@@ -135,7 +134,7 @@ class KbManagementService {
       }
     } else {
       log.debug('Resource rematch already running or scheduled. Ignore.')
-    }
+    } */
   }
 
   // "Rematch" process for ErmResources using matchKeys (Only available for PCI at the moment)

--- a/service/grails-app/services/org/olf/MatchKeyService.groovy
+++ b/service/grails-app/services/org/olf/MatchKeyService.groovy
@@ -286,23 +286,19 @@ class MatchKeyService implements DataBinder{
       }
 
       if (mk.key == 'author') {
-        schemaShape.firstAuthor = mk.value // FIXME 
-      }
-
-      if (mk.key == 'author') {
         schemaShape.firstAuthor = mk.value
       }
 
       if (mk.key == 'editor') {
-        schemaShape.firstAuthor = mk.value
+        schemaShape.firstEditor = mk.value
       }
 
       if (mk.key == 'monograph_volume') {
-        schemaShape.firstAuthor = mk.value
+        schemaShape.monographVolume = mk.value
       }
 
       if (mk.key == 'edition') {
-        schemaShape.firstAuthor = mk.value
+        schemaShape.monographEdition = mk.value
       }
     }
 

--- a/service/grails-app/services/org/olf/MatchKeyService.groovy
+++ b/service/grails-app/services/org/olf/MatchKeyService.groovy
@@ -273,6 +273,10 @@ class MatchKeyService implements DataBinder{
         ])
       }
 
+      if (mk.key == 'title_string') {
+        schemaShape.title = mk.value
+      }
+
       if (mk.key == 'date_electronic_published') {
         schemaShape.dateMonographPublished = mk.value
       }

--- a/service/grails-app/services/org/olf/general/jobs/JobRunnerService.groovy
+++ b/service/grails-app/services/org/olf/general/jobs/JobRunnerService.groovy
@@ -208,7 +208,7 @@ class JobRunnerService implements EventPublisher {
               failJob(jid)
               log.error (e.message)
               log.error ("Job execution failed", e)
-              notify ('jobs:log_info', JobContext.current.get().tenantId, JobContext.current.get().jobId,  "Job execution failed")
+              notify ('jobs:log_info', JobContext.current.get().tenantId, JobContext.current.get().jobId,  "Job execution failed: ${e.message}")
             } finally {
               JobContext.current.remove()
               org.slf4j.MDC.clear()

--- a/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/IdFirstTIRSImpl.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/IdFirstTIRSImpl.groovy
@@ -98,7 +98,8 @@ class IdFirstTIRSImpl extends BaseTIRS implements DataBinder, TitleInstanceResol
 
     // If we didn't have a class one identifier AND we weren't able to match anything via
     // a sibling match, try to do a fuzzy match as a last resort
-    if ( ( num_matches == 0 ) && ( num_class_one_identifiers == 0 ) ) {
+    // DO NOT ATTEMPT if there is no title on the citation
+    if ( ( num_matches == 0 ) && ( num_class_one_identifiers == 0 ) && citation.title ) {
       log.debug("No matches on identifier - try a fuzzy text match on title(${citation.title})");
       // No matches - try a simple title match
       candidate_list = titleMatch(citation.title,MATCH_THRESHOLD);


### PR DESCRIPTION
Disables Automatic rematch process
Fixes some MatchKey -> schema generation issues
Changes (behind disabled work) to improve the "count" performance for automatic rematching
Adds method to trigger rematch for limited list of jobs, via ResourceRematch `payload` field.
Adds error message to "Job execution failed" job log entry, to provide slightly more information to user.