### PR TITLE
fix: Duplicate key

### DIFF
--- a/service/grails-app/views/entitlement/_entitlement.gson
+++ b/service/grails-app/views/entitlement/_entitlement.gson
@@ -41,6 +41,5 @@ if (entitlement.type == 'external') {
     'activeTo' entitlement.activeTo
     'contentUpdated' entitlement.getContentUpdated()
     'haveAccess' entitlement.getHaveAccess()
-    'suppressFromDiscovery' entitlement.suppressFromDiscovery
   }
 }


### PR DESCRIPTION
Removed explicit suppressFromDiscovery key from view file to ensure we don't get duplicate keys

ERM-2001