### PR TITLE
fix: Pkg view had duplicate "identifiers" expansion

### DIFF
--- a/service/grails-app/views/pkg/_pkg.gson
+++ b/service/grails-app/views/pkg/_pkg.gson
@@ -5,7 +5,7 @@ import groovy.transform.*
 @Field
 Pkg pkg
 
-json g.render(pkg, [expand: ['remoteKb','vendor', 'type', 'subType', 'lifecycleStatus', 'availabilityScope', 'packageDescriptionUrls', 'contentTypes', 'alternateResourceNames'], excludes: ['contentItems']]) {
+json g.render(pkg, [expand: ['remoteKb','vendor', 'type', 'subType', 'lifecycleStatus', 'availabilityScope', 'packageDescriptionUrls', 'contentTypes', 'alternateResourceNames'], excludes: ['contentItems', 'identifiers']]) {
 
   resourceCount pkg.getResourceCount()
   'class' Pkg.name


### PR DESCRIPTION
Pkg view file had a manual identifiers expansion but failed to exclude the built in identifiers render, resulting in two "identifiers" keys in the resulting JSON, rendering it invalid

ERM-2174