### PR TITLE
feat: Sort Identifiers

### DIFF
--- a/service/grails-app/domain/org/olf/kb/ErmResource.groovy
+++ b/service/grails-app/domain/org/olf/kb/ErmResource.groovy
@@ -105,7 +105,12 @@ alternateResourceNames cascade: 'all-delete-orphan'
   static transients = ['approvedIdentifierOccurrences']
 
   public Set<IdentifierOccurrence> getApprovedIdentifierOccurrences() {
-    identifiers.findAll { it.status.value == 'approved' }
+    identifiers
+      .findAll { it.status.value == 'approved' }
+      .sort { a,b ->
+        a.identifier.ns.value <=> b.identifier.ns.value ?:
+        a.identifier.value <=> b.identifier.value
+      }
   }
 
   private void trunc(String fieldName, String field, int truncateLength = 255) {


### PR DESCRIPTION
Identifiers obtained via `getApprovedIdentifierOccurrences` are now sorted by default, first by namespace, then by value.

This leads to a stable representation in the UI where we have multiple identifiers within a single namespace

ERM-946