### PR TITLE
Deploy new snapshot ModuleDescriptor as v5.3.1

### DIFF
--- a/service/gradle.properties
+++ b/service/gradle.properties
@@ -11,7 +11,7 @@ gradleWrapperVersion=5.4
 
 # Application
 appName=mod-agreements
-appVersion=5.3.0-SNAPSHOT
+appVersion=5.3.1-SNAPSHOT
 dockerTagSuffix=
 dockerRepo=folioci
 


### PR DESCRIPTION
The lastest in MD Registry is erroneously "mod-agreements-5.3.0-rc.1"