### PR TITLE
fix: Bump toolkit for datastore properties fix

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -1,7 +1,7 @@
-configurations.all {
-  // Check for updates every build
-  resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
-}
+//configurations.all {
+//  // Check for updates every build
+//  resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+//}
 
 buildscript {
   repositories {
@@ -45,7 +45,7 @@ apply plugin: 'com.github.erdi.webdriver-binaries'
 apply plugin: 'com.bmuschko.docker-remote-api'
 
 repositories {
-  mavenLocal()
+//  mavenLocal()
   // jcenter()
   mavenCentral()
   maven { url 'https://repo.grails.org/grails/core' }
@@ -176,7 +176,7 @@ dependencies {
   compile 'commons-io:commons-io:2.6'
 
   compile 'com.k_int.grails:web-toolkit-ce:6.3.0'
-  compile 'com.k_int.okapi:grails-okapi:5.0.0'
+  compile 'com.k_int.okapi:grails-okapi:5.0.1'
 
   compile 'uk.co.cacoethes:groovy-handlebars-engine:0.2'
   compile 'com.github.jknack:handlebars-helpers:2.0.0'


### PR DESCRIPTION
Also re-enable the gradle artefact cache use for the build.