### PR TITLE
fix: Refdata binding

### DIFF
--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -210,8 +210,8 @@ class PackageIngestService implements DataBinder {
                   description: package_data.header.description,
             sourceDataCreated: package_data.header.sourceDataCreated,
             sourceDataUpdated: package_data.header.sourceDataUpdated,
-            availabilityScope: package_data.header.availabilityScope,
-              lifecycleStatus: package_data.header.lifecycleStatus,
+            availabilityScope: Pkg.lookupOrCreateAvailabilityScope(package_data.header.availabilityScope),
+              lifecycleStatus: Pkg.lookupOrCreateLifecycleStatus(package_data.header.lifecycleStatus),
                      remoteKb: kb,
                        vendor: vendor
           ).save(flush:true, failOnError:true)


### PR DESCRIPTION
Ensure on creation, refdata is only created via its `lookupOrCreate` domain method.

ERM-2367