### PR TITLE
ERM-2288: On updating an existing package in Agreements local KB, update/overwrite existing package metadata

### DIFF
--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -144,7 +144,7 @@ class PackageIngestService implements DataBinder {
     def urlsToRemove = [];
 
     pkg.packageDescriptionUrls.each {
-      if (!urls.contains(it.url.label)) {
+      if (!urls.contains(it.url)) {
         urlsToRemove << it
       }
     }


### PR DESCRIPTION
fix: String parsing
Accidentally tried to parse String as if it were Refdata

ERM-2288