### PR TITLE
ERM-2378: Remove defaults from ContentType

### DIFF
--- a/service/grails-app/domain/org/olf/kb/ContentType.groovy
+++ b/service/grails-app/domain/org/olf/kb/ContentType.groovy
@@ -7,7 +7,6 @@ import com.k_int.web.toolkit.refdata.RefdataValue
 public class ContentType implements MultiTenant<ContentType> {
 
 	String id
-	@Defaults(['Serials', 'Monographs', 'Databases'])
   RefdataValue contentType
 
 	static belongsTo = [ owner: Pkg ]


### PR DESCRIPTION
chore: Removed ContentType defaults

Content types are set via the ingest process and we do not perform logic on them, so we have no need to bootstrap them

ERM-2378