### PR TITLE
fix: ExternalEntitlements

### DIFF
--- a/service/grails-app/views/entitlement/_externalEntitlement.gson
+++ b/service/grails-app/views/entitlement/_externalEntitlement.gson
@@ -8,10 +8,12 @@ import com.k_int.okapi.remote_resources.OkapiLookup
 import groovy.transform.*
 import groovyx.net.http.HttpException
 
+// When fetching multiple entitlements through "index" action, do not make external fetches
+
 @Field Entitlement entitlement
 final String objectProperty = 'reference_object'
 def remoteObjValue
-if(entitlement.respondsTo(objectProperty)){
+if(actionName != 'index' && entitlement.respondsTo(objectProperty)){
   try {
     remoteObjValue = entitlement.invokeMethod(objectProperty, null)
     if (remoteObjValue instanceof Future) {

--- a/service/grails-app/views/subscriptionAgreement/_subscriptionAgreement.gson
+++ b/service/grails-app/views/subscriptionAgreement/_subscriptionAgreement.gson
@@ -50,7 +50,10 @@ if ( ( controllerName == 'subscriptionAgreement' ) && ( ['save', 'show', 'edit',
 
 def altNames = subscriptionAgreement.alternateNames?.toSorted { AlternateName a, AlternateName b -> a.name <=> b.name } ?: []
 
-json g.render(subscriptionAgreement, [expand: should_expand, excludes:['alternateNames']]) {
+def excludes = ['alternateNames']
+excludes.addAll(params.list('excludes'))
+
+json g.render(subscriptionAgreement, [expand: should_expand, excludes: excludes]) {
   cancellationDeadline subscriptionAgreement.cancellationDeadline
 
   if (actionName.toLowerCase() == 'export' && subscriptionAgreement.respondsTo('getResourceList')) {


### PR DESCRIPTION
External entitlements no longer fetch resource on `index` action. In addition, subscriptionAgreement now accepts queryParam `excludes` to allow selective exclude from the query itself

ERM-2423