### PR TITLE
ERM-2469: HibernateException: Duplicate identifier in table for AppSetting

### DIFF
--- a/service/grails-app/services/org/olf/general/StringTemplatingService.groovy
+++ b/service/grails-app/services/org/olf/general/StringTemplatingService.groovy
@@ -137,7 +137,7 @@ public class StringTemplatingService {
   @CompileStatic(SKIP)
   void refreshUrls(String tenantId) {
     log.debug "stringTemplatingService::refreshUrls called with tenantId (${tenantId})"
-    folioLockService.federatedLockAndDoWithTimeoutOrSkip("agreements:stringTemplate:refreshUrls=${tenantId}", 0) {
+    folioLockService.federatedLockAndDoWithTimeoutOrSkip("agreements-${tenantId}:stringTemplate:refreshUrls", 0) {
 
       /* Theoretically updates could happen after the process begins but before the url_refresh_cursor gets updated
       * So save the time before starting process as the new cursor pt


### PR DESCRIPTION
chore: Tweak to lock name

Tiny tweak to fix typo in lock name, and move things around a bit

ERM-2469