### PR TITLE
ERM-2475: Loading update to existing package fails if lifecycleStatus or availabilityScope are omitted

### DIFF
--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -270,8 +270,15 @@ class PackageIngestService implements DataBinder {
         }
       } else {
         pkg.sourceDataUpdated = package_data.header.sourceDataUpdated
-        pkg.lifecycleStatusFromString = package_data.header.lifecycleStatus
-        pkg.availabilityScopeFromString = package_data.header.availabilityScope
+
+        if (package_data.header.lifecycleStatus) {
+          pkg.lifecycleStatusFromString = package_data.header.lifecycleStatus
+        }
+
+        if (package_data.header.availabilityScope) {
+          pkg.availabilityScopeFromString = package_data.header.availabilityScope
+        }
+
         pkg.vendor = vendor
         pkg.description = package_data.header.description
         pkg.name = package_data.header.packageName


### PR DESCRIPTION
fix: Added null safety

In a couple of instances, fields were set to refdata using "____FromString". When that string is not present, or is `null`, this causes an exception to be thrown

ERM-2475