### PR TITLE
ERM-2514: License terms are not displayed in Publication Finder when a journal title is directly linked to an agreement

### DIFF
--- a/service/grails-app/controllers/org/olf/SubscriptionAgreementController.groovy
+++ b/service/grails-app/controllers/org/olf/SubscriptionAgreementController.groovy
@@ -49,7 +49,8 @@ class SubscriptionAgreementController extends OkapiTenantAwareController<Subscri
   def publicLookup () {
     final List<String> referenceIds = params.list('referenceId')
     final List<String> resourceIds = params.list('resourceId')
-    final List<String> disjunctiveReferences = [] + referenceIds.collect { String id ->
+    List<String> disjunctiveReferences = []
+    disjunctiveReferences = disjunctiveReferences + referenceIds.collect { String id ->
       String[] parts = id.split(/\-/)
       if (parts.length == 3) {
         // assuming progressive ID and we should search for multiples
@@ -57,7 +58,7 @@ class SubscriptionAgreementController extends OkapiTenantAwareController<Subscri
       }
       id
     }
-    
+
     final LocalDate today = LocalDate.now()
     
     respond (doTheLookup {
@@ -94,7 +95,7 @@ class SubscriptionAgreementController extends OkapiTenantAwareController<Subscri
             'in' 'direct_ent.reference', disjunctiveReferences
           }
           
-          if (resourceIds) {          
+          if (resourceIds) {
             or {
               
                // Direct PTIs


### PR DESCRIPTION
fix: Fixed publicLookup

Fixed an issue where publicLookupwas trying to create an array at the same time as writing to the array and that no longer worked (Seems to have worked at some point in the past, possibly  a change either in compiler or something inside groovy?)

However underlying lookup still isn't behaving as we might expect

ERM-2514