### PR TITLE
fix: MDC title fix

### DIFF
--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -315,11 +315,12 @@ class PackageIngestService implements DataBinder {
 
     } else {
       package_data.packageContents.eachWithIndex { ContentItemSchema pc, int index ->
+        // ENSURE MDC title is set as early as possible
+        MDC.put('title', pc.title.toString())
 
         // log.debug("Try to resolve ${pc}")
 
         try {
-
           PackageContentItem.withNewTransaction { status ->
             // Delegate out to TitleIngestService so that any shared steps can move there.
             Map titleIngestResult = titleIngestService.upsertTitle(pc, kb, trustedSourceTI)
@@ -335,8 +336,6 @@ class PackageIngestService implements DataBinder {
 
               // lets try and work out the platform for the item
               def platform_url_to_use = pc.platformUrl
-
-              MDC.put('title', pc.title.toString())
 
               if ( ( pc.platformUrl == null ) && ( pc.url != null ) ) {
                 // No platform URL, but a URL for the title. Parse the URL and generate a platform URL

--- a/service/src/main/groovy/org/olf/general/jobs/JobAwareAppender.groovy
+++ b/service/src/main/groovy/org/olf/general/jobs/JobAwareAppender.groovy
@@ -21,7 +21,7 @@ public class JobAwareAppender extends AppenderBase<ILoggingEvent> {
         for(Map.Entry entry : eventObject.getMDCPropertyMap()) {
           mdc["${entry.key}"] = "${entry.value}"
         }
-      }     
+      }
       
       if (jid) {
         switch (eventObject.level) {

--- a/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
+++ b/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
@@ -19,6 +19,8 @@ import groovy.util.logging.Slf4j
 import groovy.util.slurpersupport.GPathResult
 import groovyx.net.http.*
 
+import org.slf4j.MDC
+
 /**
  * An adapter to go between the GOKb OAI service, for example the one at
  *   https://gokbt.gbv.de/gokb/oai/index/packages?verb=ListRecords&metadataPrefix=gokb
@@ -471,6 +473,10 @@ public class GOKbOAIAdapter extends WebSourceAdapter implements KBCacheUpdater, 
 
       package_record.TIPPs?.TIPP.each { tipp_entry ->
         def tipp_status = tipp_entry?.status?.text()
+        // Ensure logging below has correct title for log export
+        if(tipp_entry?.title?.name?.text()) {
+          MDC.put("title", tipp_entry?.title?.name?.text())
+        }
 
         // log.info("Tipp.title is of size ${tipp_entry?.title?.name?.size()} and tipp_entry?.title?.name is ${tipp_entry?.title?.name}");
 


### PR DESCRIPTION
Fixed issue where in certain circumstances MDC `title` field was not being set until AFTER certain log messages were created, causing incorrect additionalInformation fields to show up in log export

ERM-2474