### PR TITLE
ERM-2474: Local KB admin: Info log export populates title element in additionalInfo with non-relevant data

### DIFF
--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -172,6 +172,8 @@ class PackageIngestService implements DataBinder {
    * @return id of package upserted
    */
   public Map upsertPackage(PackageSchema package_data, String remotekbname, boolean readOnly=false) {
+    // Remove MDC title at top of upsert package
+    MDC.remove('title')
     def result = [
       startTime: System.currentTimeMillis(),
       titleCount: 0,
@@ -536,6 +538,7 @@ class PackageIngestService implements DataBinder {
       }
 
       MDC.remove('recordNumber')
+      MDC.remove('title')
       // Need to pause long enough so that the timestamps are different
       TimeUnit.MILLISECONDS.sleep(1)
       if (result.titleCount > 0) {


### PR DESCRIPTION
fix: MDC ttitle

Remove MDC title before logging certain package-level data

ERM-2474