### PR TITLE
ERM-2638: No name of linked agreement in license

### DIFF
--- a/service/grails-app/views/remoteLicenseLink/_remoteLicenseLink.gson
+++ b/service/grails-app/views/remoteLicenseLink/_remoteLicenseLink.gson
@@ -5,13 +5,11 @@ import org.olf.erm.RemoteLicenseLink
 
 inherits template: "/remoteOkapiLink/remoteOkapiLink"
 
-def should_expand = ['status']
-
-if (params.controller == 'remoteLicenseLink' ) {
-  should_expand << 'owner'
-}
-
 json {
   'status' g.render( remoteLicenseLink.status )
   'amendments' g.render( remoteLicenseLink.amendments )
+
+  if (params.controller == 'remoteLicenseLink') {
+    'owner' g.render( remoteLicenseLink.owner )
+  }
 }


### PR DESCRIPTION
fix: remoteLicenseLink owner

remoteLicenseLink would not expand owner due to changes made to explicitly render status/amendments in PR 611: https://github.com/folio-org/mod-agreements/pull/611/files#diff-cd4d07b38e259eb6a3c473e46c4597732eadb40f315834625fcd3ad9ac16995e

ERM-2638