### PR TITLE
ERM-2639: Note not saved with license link

### DIFF
--- a/service/grails-app/views/remoteLicenseLink/_remoteLicenseLink.gson
+++ b/service/grails-app/views/remoteLicenseLink/_remoteLicenseLink.gson
@@ -8,6 +8,7 @@ inherits template: "/remoteOkapiLink/remoteOkapiLink"
 json {
   'status' g.render( remoteLicenseLink.status )
   'amendments' g.render( remoteLicenseLink.amendments )
+  'note' remoteLicenseLink.note
 
   if (params.controller == 'remoteLicenseLink') {
     'owner' g.render( remoteLicenseLink.owner )


### PR DESCRIPTION
fix: RemoteLicenseLink note

Fixed issue where RemoteLicenseLink note was not being rendered

ERM-2639