### PR TITLE
ERM-2643 handlebars rhino (XML External Entity (XXE) Injection)

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -179,7 +179,7 @@ dependencies {
   compile 'com.k_int.okapi:grails-okapi:5.0.1'
 
   compile 'uk.co.cacoethes:groovy-handlebars-engine:0.2'
-  compile 'com.github.jknack:handlebars-helpers:2.0.0'
+  compile 'com.github.jknack:handlebars-helpers:4.3.1'
   compile 'commons-fileupload:commons-fileupload:1.4'
 
   // Minio for file storage to S3


### PR DESCRIPTION
* upgrade com.github.jknack:handlebars-helpers to version 4.3.1, refs ERM-2643