### PR TITLE
ERM-2910: JSON package import fails

### DIFF
--- a/service/src/main/groovy/org/olf/dataimport/erm/ErmPackageImplWithContentItems.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/erm/ErmPackageImplWithContentItems.groovy
@@ -1,10 +1,11 @@
 package org.olf.dataimport.erm
 
 import grails.compiler.GrailsCompileStatic
+import grails.validation.Validateable
 
 // Make distinction between ErmPackageImpl which requires contentItems and that which does not.
 @GrailsCompileStatic
-class ErmPackageImplWithContentItems extends ErmPackageImpl {
+class ErmPackageImplWithContentItems extends ErmPackageImpl implements Validateable {
   static constraints = {
     contentItems minSize: 1
   }

--- a/service/src/main/groovy/org/olf/dataimport/internal/InternalPackageImplWithPackageContents.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/InternalPackageImplWithPackageContents.groovy
@@ -7,11 +7,8 @@ import grails.validation.Validateable
 
 // Make distinction between InternalPackageImpl which requires packageContents and that which does not.
 @GrailsCompileStatic
-class InternalPackageImplWithPackageContents extends InternalPackageImpl {
-  
+class InternalPackageImplWithPackageContents extends InternalPackageImpl implements Validateable {
   static constraints = {
     packageContents   minSize: 1
   }
 }
-
-


### PR DESCRIPTION
fix: JSON package import fails

Implemented Validatable directly on the extensions of ErmPackageImpl and InternalPackageImpl

ERM-2910