### PR TITLE
ERM-2919: Gracefully handle ingesting PCIs with long notes into the Local KB

### DIFF
--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -229,7 +229,7 @@ class PackageIngestService implements DataBinder {
 
               // Add/Update common properties.
               pci.with {
-                note = pc.coverageNote
+                note = StringUtils.truncate(pc.coverageNote)
                 depth = pc.coverageDepth
                 accessStart = pc.accessStart
                 accessEnd = pc.accessEnd


### PR DESCRIPTION
fix: Truncate PCI note

Added truncation step to PCI note field to ensure it's always kept down to 255 characters

ERM-2919