### PR TITLE
ERM-2961: Extend length of document URL to 2048 chars (FIX)

### DIFF
--- a/service/grails-app/migrations/docs.groovy
+++ b/service/grails-app/migrations/docs.groovy
@@ -84,5 +84,7 @@ databaseChangeLog = {
     modifyDataType (
       tableName: "document_attachment",
       columnName: "da_url",
-      newDataType: "varchar(2048)")
+      newDataType: "varchar(2048)"
+    )
+  }
 }


### PR DESCRIPTION
fix: Closing }

Fixed migration with missing closing bracket }

ERM-2961