### PR TITLE
ERM-2934 Entitlement tags default

### DIFF
--- a/service/grails-app/domain/org/olf/erm/Entitlement.groovy
+++ b/service/grails-app/domain/org/olf/erm/Entitlement.groovy
@@ -276,6 +276,7 @@ public class Entitlement implements MultiTenant<Entitlement>, Clonable<Entitleme
     }
   )
   String reference
+  Set<Tag> tags = []
 
   static belongsTo = [
     owner:SubscriptionAgreement


### PR DESCRIPTION
Added empty array as default for entitlement tags

[ERM-2934](https://issues.folio.org/browse/ERM-2934)