### PR TITLE
ERM 2992: Default behaviour for Agreements to not expand items

### DIFF
--- a/service/grails-app/views/subscriptionAgreement/_subscriptionAgreement.gson
+++ b/service/grails-app/views/subscriptionAgreement/_subscriptionAgreement.gson
@@ -51,9 +51,11 @@ if ( controllerName != 'usageDataProvider' ) {
   should_expand << 'usageDataProviders'
 }
 
+def expandItems = params.expandItems ?: false
+
 if ( ( controllerName == 'subscriptionAgreement' ) &&
  ( ['save', 'show', 'edit', 'update'].contains(actionName) ) &&
- ( params.expandItems != 'false' ) ) {
+ ( expandItems == 'true') ) {
     should_expand << 'items'
 }
 


### PR DESCRIPTION
Changed behaviour of expandItems to be set to false by default

[ERM-2992](https://issues.folio.org/browse/ERM-2992)