### PR TITLE
ERM-3044: OpenAccess custom property name

### DIFF
--- a/service/grails-app/services/org/olf/ErmHousekeepingService.groovy
+++ b/service/grails-app/services/org/olf/ErmHousekeepingService.groovy
@@ -108,7 +108,7 @@ public class ErmHousekeepingService {
             ],
             [
               "ctx" : "OpenAccess",
-              "name" : "Eligible authors",
+              "name" : "SupportPublishing",
               "type" : "Text",
               "label" : "Does this agreement support publishing",
               "description" : "Does this agreement support publishing",


### PR DESCRIPTION
Updated open access custom property name from Eligible authors to SupportPublishing

[ERM-3044](https://issues.folio.org/browse/ERM-3044)