### PR TITLE
ERM-3018: Implement GOKb Title UUID as primary match ID where available (fix enrichment)

### DIFF
--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -94,6 +94,8 @@ class PackageIngestService implements DataBinder {
 						Pkg pkg = null;
 						// Remove MDC title at top of upsert package
 						MDC.remove('title')
+            MDC.remove('packageSource')
+						MDC.remove('packageReference')
 						final def result = [
 							startTime: System.currentTimeMillis(),
 							titleCount: 0,

--- a/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/BaseTIRS.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/BaseTIRS.groovy
@@ -146,29 +146,19 @@ abstract class BaseTIRS implements TitleInstanceResolverService {
         log.error("Type (${citation.instanceMedia}) does not match 'serial' or 'monograph' for title \"${citation.title}\", skipping field enrichment.")
       }
 
-      if (title.dateMonographPublished != citation.dateMonographPublished) {
-        title.dateMonographPublished = citation.dateMonographPublished ?: ''
-        changes++
-      }
+      def enrichmentFields = [
+        'dateMonographPublished',
+        'firstAuthor',
+        'firstEditor',
+        'monographEdition',
+        'monographVolume'
+      ];
 
-      if (title.firstAuthor != citation.firstAuthor) {
-        title.firstAuthor = citation.firstAuthor ?: ''
-        changes++
-      }
-      
-      if (title.firstEditor != citation.firstEditor) {
-        title.firstEditor = citation.firstEditor ?: ''
-        changes++
-      }
-
-      if (title.monographEdition != citation.monographEdition) {
-        title.monographEdition = citation.monographEdition ?: ''
-        changes++
-      }
-
-      if (title.monographVolume != citation.monographVolume) {
-        title.monographVolume = citation.monographVolume ?: ''
-        changes++
+      enrichmentFields.each { field -> 
+        if (title[field] != citation[field]) {
+          title[field] = citation[field] ?: null
+          changes++
+        }
       }
 
       // Ensure we only save title on enrich if changes have been made

--- a/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
+++ b/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
@@ -64,6 +64,9 @@ public class GOKbOAIAdapter extends WebSourceAdapter implements KBCacheUpdater, 
     long package_sync_start_time = System.currentTimeMillis();
 
     while ( found_records ) {
+      // Clear MDC package source and reference, they'll be set lower in the code
+      MDC.remove('packageSource')
+      MDC.remove('packageReference')
 
       log.info("OAI/HTTP GET url=${packagesUrl} params=${query_params} elapsed=${System.currentTimeMillis()-package_sync_start_time}")
 


### PR DESCRIPTION
fix: Enrichment fields

Fixed enrichment fields to ensure updates to monograph fields are applied as expected (blank strings bound to null)

Small refactor to reduce repeated code logic

ERM-3018