### PR TITLE
feat: Resources use ENV_VARS

### DIFF
--- a/service/grails-app/conf/spring/resources.groovy
+++ b/service/grails-app/conf/spring/resources.groovy
@@ -4,13 +4,22 @@ import org.olf.dataimport.internal.KBManagementBean.KBIngressType
 
 // Place your Spring DSL code here
 beans = {
-  /* 
-    --- Swapping these will change the way mod-agreements handles resolution of TitleInstances --- 
-    Behaviour pre-Lotus: IdFirstTIRSImpl
-    Behaviour post-Lotus: TitleFirstTIRSImpl
-  */
-  titleInstanceResolverService(IdFirstTIRSImpl)
-  //titleInstanceResolverService(TitleFirstTIRSImpl)
+  /* --- Swapping these will change the way mod-agreements handles resolution of TitleInstances --- */
+  String TIRS = System.getenv("TIRS")
+  switch (TIRS) {
+    case 'TitleFirst':
+      titleInstanceResolverService(TitleFirstTIRSImpl)
+      break;
+    case 'WorkSourceIdentifier':
+      titleInstanceResolverService(WorkSourceIdentifierTIRSImpl)
+      break;
+    case 'IdFirst':
+    default:
+      titleInstanceResolverService(IdFirstTIRSImpl)
+      break;
+  }
+  
+  //
   //titleInstanceResolverService(WorkSourceIdentifierTIRSImpl)
 
   /*
@@ -25,8 +34,16 @@ beans = {
   */
 
   // Swap between PushKB and Harvest processes to get data into internal KB
+  String INGRESS_TYPE = System.getenv("INGRESS_TYPE")
   kbManagementBean(KBManagementBean) {
-    ingressType = KBIngressType.Harvest
-    //ingressType = KBIngressType.PushKB
+    switch (INGRESS_TYPE) {
+      case 'PushKB':
+        ingressType = KBIngressType.PushKB
+        break;
+      case 'Harvest':
+      default:
+        ingressType = KBIngressType.Harvest
+        break;
+    }
   }
 }


### PR DESCRIPTION
Set up new environment variables "TIRS" and "INGRESS_TYPE" to allow implementors' dev ops teams to swap at runtime between different methods of ingress and Title resolving

TIRS options as of this PR:
- TitleFirst
- WorkSourceIdentifier
- IdFirst (default)

INGRESS_TYPE options as of this PR:
- PushKB
- Harvest (default)

FOLIO-515