### PR TITLE
ERM-3087: Add debug message to indicate ingest mode

### DIFF
--- a/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/IdFirstTIRSImpl.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/IdFirstTIRSImpl.groovy
@@ -26,7 +26,7 @@ import org.grails.orm.hibernate.cfg.GrailsHibernateUtil
 @Transactional
 class IdFirstTIRSImpl extends BaseTIRS implements DataBinder {
   public String resolve(ContentItemSchema citation, boolean trustedSourceTI) {
-    // log.debug("TitleInstanceResolverService::resolve(${citation})");
+    log.debug("IdFirstTIRS::resolve(${citation})");
     String result = null;
 
     List<TitleInstance> candidate_list = classOneMatch(citation.instanceIdentifiers);

--- a/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/TitleFirstTIRSImpl.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/TitleFirstTIRSImpl.groovy
@@ -183,6 +183,8 @@ class TitleFirstTIRSImpl extends BaseTIRS {
   }
 
   public String resolve (ContentItemSchema citation, boolean trustedSourceTI) {
+    log.debug("TitleFirstTIRS::resolve(${citation})");
+
     TitleInstance ti = null;
 
     List<TitleInstance> candidate_list = titleMatch(citation.title, citation.instanceMedium)

--- a/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/WorkSourceIdentifierTIRSImpl.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/WorkSourceIdentifierTIRSImpl.groovy
@@ -27,7 +27,7 @@ import org.grails.orm.hibernate.cfg.GrailsHibernateUtil
 class WorkSourceIdentifierTIRSImpl extends IdFirstTIRSImpl implements DataBinder {
   // We can largely ignore passedTrustedSourceTI, and always assume that passed citations are trusted
   public String resolve(ContentItemSchema citation, boolean passedTrustedSourceTI) {
-    // log.debug("TitleInstanceResolverService::resolve(${citation})");
+    log.debug("WorkSourceIdentifierTIRS::resolve(${citation})");
     String result = null;
 
     // Error out if sourceIdentifier or sourceIdentifierNamespace do not exist
@@ -89,6 +89,7 @@ class WorkSourceIdentifierTIRSImpl extends IdFirstTIRSImpl implements DataBinder
     try {
       // If falling back to IdFirstTIRS, do not trust to update TI metadata,
       // as we may match but decide later to create new for this citation
+      log.debug("Falling back to IdFirstTIRS")
       tiId = super.resolve(citation, false);
     } catch (TIRSException tirsException) {
       // We treat a multiple title match here as NBD and move onto creation


### PR DESCRIPTION
chore: TIRS Logging

Added some small logging additions to the TIRSs so we can better tell which TIRS is in use at any given time

This manifests as `log.debug("WorkSourceIdentifierTIRS::resolve(${citation})");` (Or IdFirstTIRS etc) at the top of each citation ingested. Whilst noisy, this is not reflected in the user facing logs, only the module running logs.

ERM-3087