### PR TITLE
ERM-3063: StringTemplate.Context refdata should be internal

### DIFF
--- a/service/grails-app/domain/org/olf/general/StringTemplate.groovy
+++ b/service/grails-app/domain/org/olf/general/StringTemplate.groovy
@@ -3,7 +3,9 @@ package org.olf.general
 import com.github.jknack.handlebars.EscapingStrategy
 import com.github.jknack.handlebars.Handlebars
 import com.github.jknack.handlebars.helper.StringHelpers
+
 import com.k_int.web.toolkit.databinding.BindImmutably
+import com.k_int.web.toolkit.refdata.CategoryId
 import com.k_int.web.toolkit.refdata.Defaults
 import com.k_int.web.toolkit.refdata.RefdataValue
 
@@ -27,6 +29,7 @@ class StringTemplate implements MultiTenant<StringTemplate> {
   Date dateCreated
   Date lastUpdated
 
+  @CategoryId(defaultInternal=true)
   @Defaults(['urlProxier', 'urlCustomiser'])
   RefdataValue context
   
@@ -55,7 +58,7 @@ class StringTemplate implements MultiTenant<StringTemplate> {
     id column:'strt_id', generator: 'uuid2', length:36
     name column:'strt_name'
     rule column:'strt_rule'
-    context column:'strt_context'
+    context column:'strt_context_fk'
     dateCreated column: 'strt_date_created'
     lastUpdated column: 'strt_last_updated'
     idScopes cascade: 'all-delete-orphan', joinTable: [name: 'string_template_scopes', key: 'string_template_id', column: 'id_scope']

--- a/service/grails-app/migrations/update-mod-agreements-6-0.groovy
+++ b/service/grails-app/migrations/update-mod-agreements-6-0.groovy
@@ -220,4 +220,55 @@ databaseChangeLog = {
 			column(name: "id_value")
 		}
 	}
+
+	changeSet(author: "Jack_golding (manual)", id: "20231128-1115-001") {
+		grailsChange {
+			change {
+				sql.eachRow("""
+					SELECT DISTINCT strt_context FROM ${database.defaultSchemaName}.string_template
+					INNER JOIN ${database.defaultSchemaName}.refdata_value
+						ON string_template.strt_context = refdata_value.rdv_id
+					WHERE NOT EXISTS (
+						SELECT rdv_id FROM ${database.defaultSchemaName}.refdata_value WHERE rdv_id = strt_context
+					)""".toString()
+				) { def row ->
+					sql.execute("""
+						INSERT INTO ${database.defaultSchemaName}.refdata_value
+						(rdv_id, rdv_version, rdv_value, rdv_owner, rdv_label)
+						${row.strt_context} as id,
+						0 as version,
+						'missing_context_${row.strt_context}' as value,
+						(
+							SELECT rdc_id FROM  ${database.defaultSchemaName}.refdata_category
+							WHERE rdc_description='StringTemplate.Context'
+						) as owner,
+						'Missing context ${row.strt_context}' as label
+					""".toString())
+				}
+			}
+		}
+	}
+
+	changeSet(author: "Jack_golding (manual)", id: "20231128-1115-002") {
+    grailsChange {
+      change {
+        sql.execute("""
+          UPDATE ${database.defaultSchemaName}.refdata_category SET internal = true
+            WHERE rdc_description IN ('StringTemplate.Context')
+        """.toString())
+      }
+    }
+  }
+
+	changeSet(author: "Jack_Golding (manual)", id: "20231128-1115-003") {
+    renameColumn(tableName: "string_template", oldColumnName: "strt_context", newColumnName: "strt_context_fk")
+
+    addForeignKeyConstraint(baseColumnNames: "strt_context_fk",
+        baseTableName: "string_template",
+        constraintName: "string_template_context_fk",
+        deferrable: "false",
+        initiallyDeferred: "false",
+        referencedColumnNames: "rdv_id",
+        referencedTableName: "refdata_value")
+  }
 }


### PR DESCRIPTION
Updated column mapping and defaultInternalValue for StringTemplate.Context, written migration for all missing entries, renamed column within string_template table and migrated foreign key constraint

[ERM-3063](https://issues.folio.org/browse/ERM-3063)