### PR TITLE
ERM-3118: ehchache 2 NamedThreadFactory

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -147,8 +147,6 @@ dependencies {
 
   implementation 'com.github.zafarkhaja:java-semver:0.9.0'
   implementation 'org.z3950.zing:cql-java:1.13'
-  /* Newer versions of ehcache are at org.ehcache:ehcache, but do not include NamedThreadFactory */
-  implementation 'net.sf.ehcache:ehcache:2.10.9.2'
 
   // Minio for file storage to S3
   implementation "io.minio:minio:8.5.1"

--- a/service/grails-app/services/org/olf/general/StringTemplatingService.groovy
+++ b/service/grails-app/services/org/olf/general/StringTemplatingService.groovy
@@ -41,7 +41,6 @@ import grails.gorm.multitenancy.Tenants
 import grails.orm.HibernateCriteriaBuilder
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
-import net.sf.ehcache.util.NamedThreadFactory
 import services.k_int.core.FolioLockService
 
 /**

--- a/service/src/main/groovy/org/olf/general/NamedThreadFactory.groovy
+++ b/service/src/main/groovy/org/olf/general/NamedThreadFactory.groovy
@@ -1,0 +1,66 @@
+/**
+ *  Copyright Terracotta, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.olf.general;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A {@link ThreadFactory} that sets names to the threads created by this factory. Threads created by this factory
+ * will take names in the form of the string <code>namePrefix + " thread-" + threadNum</code> where <tt>threadNum</tt> is the 
+ * count of threads created by this type of factory.
+ * 
+ * @author <a href="mailto:asanoujam@terracottatech.com">Abhishek Sanoujam</a>
+ * 
+ */
+public class NamedThreadFactory implements ThreadFactory {
+
+    private static AtomicInteger threadNumber = new AtomicInteger(1);
+    private final String namePrefix;
+    private final boolean daemon;
+
+    /**
+     * Constructor accepting the prefix of the threads that will be created by this {@link ThreadFactory}
+     * 
+     * @param namePrefix
+     *            Prefix for names of threads
+     */
+    public NamedThreadFactory(String namePrefix, boolean daemon) {
+        this.namePrefix = namePrefix;
+        this.daemon = daemon;
+
+    }
+    /**
+     * Constructor accepting the prefix of the threads that will be created by this {@link ThreadFactory}
+     *
+     * @param namePrefix
+     *            Prefix for names of threads
+     */
+    public NamedThreadFactory(String namePrefix) {
+        this(namePrefix, false);
+    }
+
+    /**
+     * Returns a new thread using a name as specified by this factory {@inheritDoc}
+     */
+    public Thread newThread(Runnable runnable) {
+        final Thread thread = new Thread(runnable, namePrefix + " thread-" + threadNumber.getAndIncrement());
+        thread.setDaemon(daemon);
+        return thread;
+    }
+
+}


### PR DESCRIPTION
Added NamedThreadFactory util from ehcache package to org.olf.general
Removed ehcache 2 dependency from build.gradle

[ERM-3118](https://issues.folio.org/browse/ERM-3118)