### PR TITLE
feat: Change default TIRS

### DIFF
--- a/service/grails-app/conf/spring/resources.groovy
+++ b/service/grails-app/conf/spring/resources.groovy
@@ -7,15 +7,15 @@ beans = {
   /* --- Swapping these will change the way mod-agreements handles resolution of TitleInstances --- */
   String TIRS = System.getenv("TIRS")
   switch (TIRS) {
+    case 'IdFirst':
+      titleInstanceResolverService(IdFirstTIRSImpl)
+      break;
     case 'TitleFirst':
       titleInstanceResolverService(TitleFirstTIRSImpl)
       break;
     case 'WorkSourceIdentifier':
-      titleInstanceResolverService(WorkSourceIdentifierTIRSImpl)
-      break;
-    case 'IdFirst':
     default:
-      titleInstanceResolverService(IdFirstTIRSImpl)
+      titleInstanceResolverService(WorkSourceIdentifierTIRSImpl)
       break;
   }
   


### PR DESCRIPTION
We change the default TIRS (including on the snapshot/snapshot2 reference envs) to WorkSourceIdentifierTIRS. To get back old behaviour implementors MUST use TIRS='IdFirst' environment variable