### PR TITLE
ERM-3152: Ensure external data source set to idle after zombie job found

### DIFF
--- a/service/grails-app/domain/org/olf/general/jobs/PackageIngestJob.groovy
+++ b/service/grails-app/domain/org/olf/general/jobs/PackageIngestJob.groovy
@@ -10,12 +10,11 @@ class PackageIngestJob extends PersistentJob implements MultiTenant<PackageInges
     kbHarvestService.triggerPackageCacheUpdate()
   }
 
-	@Override
-  public void handleInterruptedJob() {
+  final Closure onInterrupted = {String tenantId, String jobId ->
 		// We need to update the harvest job and set syncStatus to something other than in-process
 		// Probably we should just update all rkb.syncStatus = 'idle'
-    log.info "Requesting that kbHarvestService resets syncStatus to idle on any interrupted KB connections"
+    // This work is handled in kbHarvestService
+    log.info("onInterrupted called for job(${jobId}) in tenant(${tenantId}).")
     kbHarvestService.handleInterruptedJob()
   }
-
 }

--- a/service/grails-app/domain/org/olf/general/jobs/PackageIngestJob.groovy
+++ b/service/grails-app/domain/org/olf/general/jobs/PackageIngestJob.groovy
@@ -9,4 +9,13 @@ class PackageIngestJob extends PersistentJob implements MultiTenant<PackageInges
     log.info "Running Package Ingest Job"
     kbHarvestService.triggerPackageCacheUpdate()
   }
+
+	@Override
+  public void handleInterruptedJob() {
+		// We need to update the harvest job and set syncStatus to something other than in-process
+		// Probably we should just update all rkb.syncStatus = 'idle'
+    log.info "Requesting that kbHarvestService resets syncStatus to idle on any interrupted KB connections"
+    kbHarvestService.handleInterruptedJob()
+  }
+
 }

--- a/service/grails-app/domain/org/olf/general/jobs/PersistentJob.groovy
+++ b/service/grails-app/domain/org/olf/general/jobs/PersistentJob.groovy
@@ -115,8 +115,13 @@ abstract class PersistentJob extends SingleFileAttachment implements EventBusAwa
 
 	/**
 	 * If the job was interrupted, this method is called by the framework to do any job specific handling of an interrupted
-	 * scenario. Jobs needing this handling should @Override this method.
+	 * scenario.
+
+    * This needs overwriting in implementing classes that want special logic
 	 */
-	public void handleInterruptedJob() {
-	}
+  Runnable getOnInterrupted() {
+    return { String tenantId, String jobId ->
+      log.debug("No onInterrupted implemented, default implementation called as fallback")
+    }
+  }
 }

--- a/service/grails-app/domain/org/olf/general/jobs/PersistentJob.groovy
+++ b/service/grails-app/domain/org/olf/general/jobs/PersistentJob.groovy
@@ -112,4 +112,11 @@ abstract class PersistentJob extends SingleFileAttachment implements EventBusAwa
   String toString() {
     "${name}"
   }
+
+	/**
+	 * If the job was interrupted, this method is called by the framework to do any job specific handling of an interrupted
+	 * scenario. Jobs needing this handling should @Override this method.
+	 */
+	public void handleInterruptedJob() {
+	}
 }

--- a/service/grails-app/services/org/olf/KbHarvestService.groovy
+++ b/service/grails-app/services/org/olf/KbHarvestService.groovy
@@ -109,8 +109,7 @@ where rkb.type is not null
     }
   }
 
-	/*
-	This task is pre-jobs so no longer used
+	// This task is only used directly through a call to the AdminController
   @Scheduled(fixedDelay = 3600000L, initialDelay = 60000L) // Run task every hour, wait 1 minute.
   void triggerSync() {
     log.debug "Running scheduled KB sync for all tenants :{}", Instant.now()
@@ -125,7 +124,7 @@ where rkb.type is not null
       }
     }
   }
-	*/
+	
 
   // Want this closure to be accessible by each of the triggerCacheUpdate methods below, but compileStatic can't seem to SKIP a Closure declaration, so declare as return from a method instead
   @CompileStatic(SKIP)
@@ -250,15 +249,18 @@ where rkb.type is not null
   }
 
 	public void handleInterruptedJob() {
-		log.debug("It seems that the harvest job was interrupted. We should set all remote KBs to idle");
+		log.debug("KBHarvestService::handleInterruptedJob() called. Setting all remote KBs to idle");
 		try {
-		RemoteKB.executeUpdate('update RemoteKB set syncStatus = :idle',[idle:'idle']);
+		  RemoteKB.executeUpdate('update RemoteKB set syncStatus = :idle',[idle:'idle']);
 		}
 		catch ( Exception e ) {
 			e.printStackTrace();
 		}
 		finally {
-			log.warn("handleInterruptedJob completed");
+      // This might ought to be in debug to bring in line with other methods in here, 
+      // although it might be more useful to know it happened since the call log above is "debug" level
+      // Default logback config has this service at "DEBUG" level anyway so it might not matter.
+			log.warn("KBHarvestService::handleInterruptedJob() completed");
 		}
 	}
 }

--- a/service/grails-app/services/org/olf/KbHarvestService.groovy
+++ b/service/grails-app/services/org/olf/KbHarvestService.groovy
@@ -109,6 +109,8 @@ where rkb.type is not null
     }
   }
 
+	/*
+	This task is pre-jobs so no longer used
   @Scheduled(fixedDelay = 3600000L, initialDelay = 60000L) // Run task every hour, wait 1 minute.
   void triggerSync() {
     log.debug "Running scheduled KB sync for all tenants :{}", Instant.now()
@@ -123,6 +125,7 @@ where rkb.type is not null
       }
     }
   }
+	*/
 
   // Want this closure to be accessible by each of the triggerCacheUpdate methods below, but compileStatic can't seem to SKIP a Closure declaration, so declare as return from a method instead
   @CompileStatic(SKIP)
@@ -245,4 +248,17 @@ where rkb.type is not null
 
     log.debug("KbHarvestService::triggerCacheUpdate() completed")
   }
+
+	public void handleInterruptedJob() {
+		log.debug("It seems that the harvest job was interrupted. We should set all remote KBs to idle");
+		try {
+		RemoteKB.executeUpdate('update RemoteKB set syncStatus = :idle',[idle:'idle']);
+		}
+		catch ( Exception e ) {
+			e.printStackTrace();
+		}
+		finally {
+			log.warn("handleInterruptedJob completed");
+		}
+	}
 }

--- a/service/grails-app/services/org/olf/general/jobs/JobRunnerService.groovy
+++ b/service/grails-app/services/org/olf/general/jobs/JobRunnerService.groovy
@@ -154,25 +154,23 @@ order by pj.dateCreated
       pj.status = RefdataValue.lookupOrCreate(statusCat, 'Ended')
       
       
-      Runnable handleInterruptedJob = pj.getHandleInterruptedJob();
+      Runnable onInterrupted = pj.getOnInterrupted();
 
       // Call any job-specific handling
-      if (Closure.isAssignableFrom(handleInterruptedJob.class)) {
+      if (Closure.isAssignableFrom(onInterrupted.class)) {
         // Change the delegate to this class so we can control access to beans.
-        Closure handleInterruptedJobC = handleInterruptedJob as Closure
+        Closure onInterruptedC = onInterrupted as Closure
   //      final JobRunnerService me = this
-        handleInterruptedJobC.setDelegate(this)
-        handleInterruptedJobC.setResolveStrategy(Closure.DELEGATE_FIRST)
+        onInterruptedC.setDelegate(this)
+        onInterruptedC.setResolveStrategy(Closure.DELEGATE_FIRST)
 
         // Also pass in the current tenant id and job id
-        handleInterruptedJob = handleInterruptedJobC.curry(tenantId, jid)
+        onInterrupted = onInterruptedC.curry(tenantId, jid)
       }
 
-      handleInterruptedJob.run()
+      onInterrupted.run()
       // I don't think we want to use the special thread pool here
-      //executorSvc.execute(handleInterruptedJob)
-
-      //pj.handleInterruptedJob(tenantId, jid);
+      //executorSvc.execute(onInterrupted)
       pj.save( failOnError: true, flush:true )
     }
   }


### PR DESCRIPTION
Add onInterrupted hook to PersistentJob, which uses the closure mechanism already in place for "work", thereby alllowing JobRunnerService to control the beans the implementing job has access to.

Implement onInterrupted for PackageIngestJob, allowing for the resetting to idle of an external KB when a job has been interrupted