### PR TITLE
fix: Stupid syntax error

### DIFF
--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -540,7 +540,7 @@
           "pathPattern": "/erm/admin/triggerHousekeeping",
           "unit": "hour",
           "delay": "24"
-        },
+        }
       ]
     }
   ],


### PR DESCRIPTION
Fixed an incredibly stupid syntax error caused by leaving a comma in the ModuleDescriptor. Not sure how this didn't break something locally but hey ho