### PR TITLE
ERM-3155: URL on PTI is limited to 255 characters which can lead data ingest to fail if an e-resource has a long URL

### DIFF
--- a/service/grails-app/migrations/update-mod-agreements-6-1.groovy
+++ b/service/grails-app/migrations/update-mod-agreements-6-1.groovy
@@ -6,4 +6,13 @@ databaseChangeLog = {
 	changeSet(author: "efreestone (manual)", id: "20240219-1445-002") {
     dropTable(tableName: "naive_match_key_assignment_job")
   }
+
+  changeSet(author: "efreestone (manual)", id: "20240221-1120-001") {
+    modifyDataType(
+      tableName: "platform_title_instance",
+      columnName: "pti_url",
+      newDataType: "VARCHAR(2083)",
+      confirm: "Successfully updated the pti_url column."
+    )
+  }
 }


### PR DESCRIPTION
feat: URL length

Increase length of URL for PTI to 2083 characters, to bring in line with accepted browser limits. Raised from 255 characters which caused problems in very select circumstances

ERM-3155