### PR TITLE
feat: Add remote source current title count property to data model

### DIFF
--- a/service/grails-app/domain/org/olf/kb/Pkg.groovy
+++ b/service/grails-app/domain/org/olf/kb/Pkg.groovy
@@ -20,6 +20,7 @@ public class Pkg extends ErmResource implements MultiTenant<Pkg> {
   Org vendor
   Date sourceDataCreated
   Date sourceDataUpdated
+  Integer titleCount
   @Defaults(['Current', 'Retired', 'Expected', 'Deleted'])
   RefdataValue lifecycleStatus
   @Defaults(['Global'])
@@ -27,7 +28,6 @@ public class Pkg extends ErmResource implements MultiTenant<Pkg> {
   Set<PackageDescriptionUrl> packageDescriptionUrls
   Set<ContentType> contentTypes
   Set<AvailabilityConstraint> availabilityConstraints
-
   
   // Declaring this here will provide defaults for the type defined in ErmResource but not create
   // a subclass specific column
@@ -56,6 +56,7 @@ public class Pkg extends ErmResource implements MultiTenant<Pkg> {
                        vendor column:'pkg_vendor_fk'
             sourceDataCreated column:'pkg_source_data_created'
             sourceDataUpdated column:'pkg_source_data_updated'
+                   titleCount column:'pkg_title_count'
               lifecycleStatus column:'pkg_lifecycle_status_fk'
             availabilityScope column:'pkg_availability_scope_fk'
        packageDescriptionUrls cascade: 'all-delete-orphan'
@@ -68,6 +69,7 @@ public class Pkg extends ErmResource implements MultiTenant<Pkg> {
              source(nullable:false, blank:false)
           reference(nullable:false, blank:false)
     nominalPlatform(nullable:true, blank:false)
+         titleCount(nullable:true, blank:false)
              vendor(nullable:true, blank:false)
   sourceDataCreated(nullable:true, blank:false)
   sourceDataUpdated(nullable:true, blank:false)

--- a/service/grails-app/migrations/update-mod-agreements-6-0.groovy
+++ b/service/grails-app/migrations/update-mod-agreements-6-0.groovy
@@ -829,4 +829,10 @@ databaseChangeLog = {
         referencedColumnNames: "rdv_id",
         referencedTableName: "refdata_value")
   }
+
+	changeSet(author: "Jack_Golding (manual)", id: "20240223-1010-001") {
+  	addColumn(tableName: "package") {	
+			column(name: "pkg_title_count", type: "BIGINT"){ constraints(nullable: "true") }
+  	}
+	}
 }

--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -273,6 +273,7 @@ class PackageIngestService implements DataBinder {
                     source: package_data.header.packageSource,
                 reference: package_data.header.packageSlug,
               description: package_data.header.description,
+               titleCount: (package_data.header.titleCount ?: null),
         sourceDataCreated: package_data.header.sourceDataCreated,
         sourceDataUpdated: package_data.header.sourceDataUpdated,
         availabilityScope: ( package_data.header.availabilityScope != null ? Pkg.lookupOrCreateAvailabilityScope(package_data.header.availabilityScope) : null ),

--- a/service/src/main/groovy/org/olf/dataimport/erm/ErmPackageImpl.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/erm/ErmPackageImpl.groovy
@@ -25,6 +25,7 @@ class ErmPackageImpl implements PackageHeaderSchema, PackageSchema, Validateable
   Boolean trustedSourceTI
   Date sourceDataCreated
   Date sourceDataUpdated
+  Integer titleCount
   String availabilityScope
   String lifecycleStatus
   String description
@@ -105,6 +106,12 @@ class ErmPackageImpl implements PackageHeaderSchema, PackageSchema, Validateable
   public Date getSourceDataUpdated() {
     sourceDataUpdated
   }
+
+  @Override
+  public Integer getTitleCount() {
+    titleCount
+  }
+
 
   @Override
   public String getAvailabilityScope() {

--- a/service/src/main/groovy/org/olf/dataimport/internal/HeaderImpl.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/HeaderImpl.groovy
@@ -28,6 +28,7 @@ class HeaderImpl implements PackageHeaderSchema, Validateable {
   String description
   Date sourceDataCreated
   Date sourceDataUpdated
+  Integer titleCount
   String availabilityScope
   List<ContentType> contentTypes
   List<AlternateResourceName> alternateResourceNames

--- a/service/src/main/groovy/org/olf/dataimport/internal/PackageSchema.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/PackageSchema.groovy
@@ -70,6 +70,7 @@ interface PackageSchema extends Validateable {
     Boolean getTrustedSourceTI()
     Date getSourceDataCreated()
     Date getSourceDataUpdated()
+    Integer getTitleCount()
     String getAvailabilityScope()
     String getLifecycleStatus()
     Collection<ContentTypeSchema> getContentTypes()


### PR DESCRIPTION
Add a new property to store a number which represents the number of current titles in the source data for a package.

ERM-3140