### PR TITLE
fix: ERM-3177: Check on `noSICount` in WorkSourceIdentifierTIRSImpl is not correct

### DIFF
--- a/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/WorkSourceIdentifierTIRSImpl.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/WorkSourceIdentifierTIRSImpl.groovy
@@ -45,13 +45,19 @@ class WorkSourceIdentifierTIRSImpl extends IdFirstTIRSImpl implements DataBinder
         return false;
       }
 
+      // This assumes that IdentiferOccurrences can only be attached to Works as the sourceIdentifier.
+      // If this changes then rework will be needed.
       long noSICount = Work.executeQuery("""
-        SELECT COUNT(w) FROM Work w WHERE w.sourceIdentifier = null
-      """.toString())?.get(0);
+        SELECT COUNT(w) FROM Work w
+        LEFT JOIN IdentifierOccurrence io ON io.resource = w.id
+        WHERE io.id = null
+        """.toString())?.get(0);
 
+/*
       long workCount = Work.executeQuery("""
         SELECT COUNT(w) FROM Work w
       """.toString())?.get(0);
+*/
 
       // For now keep the fallback unless there are NO Works in the system without SI
       if (noSICount == 0) {
@@ -74,7 +80,6 @@ class WorkSourceIdentifierTIRSImpl extends IdFirstTIRSImpl implements DataBinder
     // Error out if sourceIdentifier or sourceIdentifierNamespace do not exist
     ensureSourceIdentifierFields(citation);
 
-    // TODO Check this works with the switch to grabbing only id
     List<String> candidate_works = Work.executeQuery("""
       SELECT w.id FROM Work as w
       WHERE


### PR DESCRIPTION
Previously WorkSourceIdentifierTIRS used check `work.sourceIdentifier = null` in the HQL statement, assuming that the Hibernate query language and GORM would play nicely for null check. This was incorrect however, so it has been swapped for a more direct count, of the number of Works LEFT JOIN the IdentifierOccurrences, where the IdentifierOccurrence is null.

NOTE: This will only work so long as Work only has a single IdentifierOccurrence attached to it in this manner. Reworks will be needed if this changes.

ERM-3177