### PR TITLE
ERM-3157: Missed declaration of backend permissions

### DIFF
--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -514,22 +514,6 @@
       ]
     },
     {
-      "id" : "codex",
-      "version" : "3.0",
-      "interfaceType": "multiple",
-      "handlers" : [
-        {
-          "methods" : [ "GET" ],
-          "pathPattern" : "/codex-instances",
-          "permissionsRequired" : [ "codex.collection.get" ]
-        }, {
-          "methods" : [ "GET" ],
-          "pathPattern" : "/codex-instances/{id}",
-          "permissionsRequired" : [ "codex.item.get" ]
-        }
-      ]
-    },
-    {
       "id": "_timer",
       "version": "1.0",
       "interfaceType": "system",


### PR DESCRIPTION
fix: Removed unused codex endpoints

Codex permissions were previously removed but codex endpoints were still included in the module descriptor, these have now been removed

ERM-3157