### PR TITLE
 ERM-3181: sourceTitleCount should not be required on uploading packages via JSON using mod-agreements-package schema

### DIFF
--- a/service/grails-app/services/org/olf/ImportService.groovy
+++ b/service/grails-app/services/org/olf/ImportService.groovy
@@ -97,7 +97,7 @@ class ImportService implements DataBinder {
     envelope.records?.each { Map record ->
       // Ingest 1 package at a time.
       Map importResult = importPackage (record, ErmPackageImplWithContentItems)
-      
+                  
       if (importResult.packageImported) {
         packageCount ++
         String packageId = importResult.packageId
@@ -115,7 +115,7 @@ class ImportService implements DataBinder {
   }
   
   private Map importPackage (final Map record, final Class<? extends PackageSchema> schemaClass) {
-    boolean packageImported = true
+    boolean packageImported = false
     String packageId = ""
 
     final PackageSchema pkg = schemaClass.newInstance()

--- a/service/src/main/groovy/org/olf/dataimport/erm/ErmPackageImpl.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/erm/ErmPackageImpl.groovy
@@ -63,6 +63,7 @@ class ErmPackageImpl implements PackageHeaderSchema, PackageSchema, Validateable
     availabilityScope  nullable: true, blank: false
     sourceDataCreated  nullable: true, blank: false
     sourceDataUpdated  nullable: true, blank: false
+    sourceTitleCount nullable: true, blank: false
     lifecycleStatus    nullable: true, blank: false
   }
 


### PR DESCRIPTION
fix: ERM-3181

Tweaked packageSchema to allow packages imported via ERM schema to _not_ provide a sourceTitleCount. Also made tweak to import logging to better reflect the number of packages imported, as it previously defaulted to "imported: true" whether the package made it past validation or not

ERM-3181