### PR TITLE
ERM-3190: DB connections are not being released

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -200,7 +200,7 @@ bootRun {
     '-Dspring.output.ansi.enabled=always',
     '-noverify',
     '-XX:TieredStopAtLevel=1',
-    '-Xmx1024m')
+    '-Xmx1592m')
 	sourceResources sourceSets.main
 	String springProfilesActive = 'spring.profiles.active'
 	systemProperty springProfilesActive, System.getProperty(springProfilesActive)


### PR DESCRIPTION
fix: Changed transaction handling in JobRunnerService

Spring @Transactional annotation does not apply on `protected` or `private` methods. Previously Grails 5 either permitted this or this being ignored did not cause us an issue. However with grails 6 the handling of transactions has changed, and so we need to explicitly wrap the execution of the job in a GormUtils withNewReadOnlyTransaction.

Also increased the heap size in build.gradle for developers running the module using bootRun, to 1.5G

ERM-3190