### PR TITLE
ERM-3187: Re-write query to show "list of resources in an agreement" for improved performance

### DIFF
--- a/service/grails-app/controllers/org/olf/UrlMappings.groovy
+++ b/service/grails-app/controllers/org/olf/UrlMappings.groovy
@@ -23,6 +23,13 @@ class UrlMappings {
       "/resources/future"     (action: 'futureResources', method: 'GET')
       "/resources/dropped"    (action: 'droppedResources', method: 'GET')
 
+      // The "static" versions will ONLY return PCIs, not PTIs linked directly (for now)
+      "/resources/static"    (action: 'staticResources', method: 'GET')
+      "/resources/static/all"    (action: 'staticResources', method: 'GET')
+      "/resources/static/current"    (action: 'staticCurrentResources', method: 'GET')
+      "/resources/static/dropped"    (action: 'staticDroppedResources', method: 'GET')
+      "/resources/static/future"    (action: 'staticFutureResources', method: 'GET')
+
       "/resources/export/$format?"          (controller: 'export', method: 'GET')
       "/resources/export/current/$format?"  (controller: 'export', action: 'current', method: 'GET')
       "/resources/export/all/$format?"  (controller: 'export', action: 'index', method: 'GET')

--- a/service/grails-app/views/ermResource/_ermResource.gson
+++ b/service/grails-app/views/ermResource/_ermResource.gson
@@ -14,50 +14,54 @@ Map customCoverageMap = request?.getAttribute("${controllerName}.${actionName}.c
 // Check for custom coverage on this resource.
 List customCoverageList = customCoverageMap?.get("${ermResource.id}")
 
-json {
+def minimalView = params.minimalView ?: false
+if (minimalView && ermResource.class.name == 'org.olf.kb.PackageContentItem') {
+  json g.render (template: '/packageContentItem/minimalPackageContentItem', model: (binding.variables + [customCoverageList: customCoverageList]))
+} else {
+  json {
+    'id' ermResource.id
+    'class' ermResource.class.name
+    'name' ermResource.getName()
 
-  'id' ermResource.id
-  'class' GrailsHibernateUtil.unwrapIfProxy(ermResource).class.name
-  'name' ermResource.getName()
-  'suppressFromDiscovery' ermResource.suppressFromDiscovery
-  'tags' g.render(ermResource.tags)
-  'alternateResourceNames' g.render(ermResource.alternateResourceNames)
-  
-  RefdataValue rdv = ermResource.getType() 
-  
-  if (rdv) {
-    'type' g.render (rdv)
-  }
-  
-  if (ermResource.publicationType) {
-    'publicationType' g.render (ermResource.publicationType)
-  }
+    'suppressFromDiscovery' ermResource.suppressFromDiscovery
+    'tags' g.render(ermResource.tags)
+    'alternateResourceNames' g.render(ermResource.alternateResourceNames)
+    
+    RefdataValue rdv = ermResource.getType() 
+    
+    if (rdv) {
+      'type' g.render (rdv)
+    }
+    
+    if (ermResource.publicationType) {
+      'publicationType' g.render (ermResource.publicationType)
+    }
 
-  if (ermResource.subType) {
-    'subType' g.render (ermResource.subType)
-  }
-  
-  if (customCoverageList) {
+    if (ermResource.subType) {
+      'subType' g.render (ermResource.subType)
+    }
     
-    'coverage' g.render (customCoverageList)
-    'customCoverage' true
+    if (customCoverageList) {
+      
+      'coverage' g.render (customCoverageList)
+      'customCoverage' true
+      
+    } else if (ermResource.coverage) {
+      
+      'coverage' g.render (ermResource.coverage)
+      'customCoverage' false
+      
+    } else {
+      'coverage' []
+      'customCoverage' false
+    }
     
-  } else if (ermResource.coverage) {
+    if (params.controller == 'export' ) {
+      // add extra fields for export
+      
+    }
     
-    'coverage' g.render (ermResource.coverage)
-    'customCoverage' false
-     
-  } else {
-    'coverage' []
-    'customCoverage' false
+    //Render the full representation of whatever this object is.
+    '_object' g.render(ermResource)
   }
-  
-  if (params.controller == 'export' ) {
-     // add extra fields for export
-     
-  }
-  
-  // Render the full representation of whatever this object is.
-  '_object' g.render(GrailsHibernateUtil.unwrapIfProxy(ermResource))
-  
 }

--- a/service/grails-app/views/packageContentItem/_minimalPackageContentItem.gson
+++ b/service/grails-app/views/packageContentItem/_minimalPackageContentItem.gson
@@ -1,0 +1,42 @@
+import org.olf.kb.PackageContentItem
+
+import groovy.transform.*
+
+@Field
+PackageContentItem packageContentItem
+
+@Field
+List customCoverageList
+
+// Borrowed from the ermResource view file
+// TODO custom view here?
+//Map customCoverageMap = request?.getAttribute("${controllerName}.${actionName}.customCoverage") as Map
+// Check for custom coverage on this resource.
+//List customCoverageList = customCoverageMap?.get("${packageContentItem.id}")
+
+json {
+  'tiName' packageContentItem.pti.titleInstance.name
+  'platformUrl' packageContentItem.pti.url
+  'platformName' packageContentItem.pti.platform.name
+
+  identifiers (packageContentItem.pti.titleInstance.approvedIdentifierOccurrences) {IdentifierOccurrence occurrence ->
+    identifier g.render(occurrence.identifier)
+  }
+  'pkg' packageContentItem.pkg.name
+  'accessStart' packageContentItem.accessStart
+  'accessEnd' packageContentItem.accessEnd
+
+  if (customCoverageList) {
+    'coverage' g.render (customCoverageList)
+    'customCoverage' true
+
+  } else if (packageContentItem.coverage) {
+
+    'coverage' g.render (packageContentItem.coverage)
+    'customCoverage' false
+
+  } else {
+    'coverage' []
+    'customCoverage' false
+  }
+}

--- a/service/grails-app/views/packageContentItem/_minimalPackageContentItem.gson
+++ b/service/grails-app/views/packageContentItem/_minimalPackageContentItem.gson
@@ -8,12 +8,6 @@ PackageContentItem packageContentItem
 @Field
 List customCoverageList
 
-// Borrowed from the ermResource view file
-// TODO custom view here?
-//Map customCoverageMap = request?.getAttribute("${controllerName}.${actionName}.customCoverage") as Map
-// Check for custom coverage on this resource.
-//List customCoverageList = customCoverageMap?.get("${packageContentItem.id}")
-
 json {
   'tiName' packageContentItem.pti.titleInstance.name
   'platformUrl' packageContentItem.pti.url

--- a/service/grails-app/views/pkg/_pkg.gson
+++ b/service/grails-app/views/pkg/_pkg.gson
@@ -5,7 +5,25 @@ import groovy.transform.*
 @Field
 Pkg pkg
 
-json g.render(pkg, [expand: ['remoteKb','vendor', 'type', 'subType', 'lifecycleStatus', 'availabilityScope', 'packageDescriptionUrls', 'contentTypes', 'alternateResourceNames', 'availabilityConstraints'], excludes: ['contentItems', 'identifiers']]) {
+final def should_expand = [
+  'remoteKb',
+  'type',
+  'subType',
+  'lifecycleStatus',
+  'availabilityScope',
+  'packageDescriptionUrls',
+  'contentTypes',
+  'alternateResourceNames',
+  'availabilityConstraints',
+  'vendor'
+];
+
+final def should_exclude = [
+  'contentItems',
+  'identifiers'
+];
+
+json g.render(pkg, [expand: should_expand, excludes: should_exclude]) {
 
   resourceCount pkg.getResourceCount()
   'class' Pkg.name

--- a/service/grails-app/views/subscriptionAgreement/staticCurrentResources.gson
+++ b/service/grails-app/views/subscriptionAgreement/staticCurrentResources.gson
@@ -1,0 +1,1 @@
+json g.render (template: '/resource/resourceList', model: (binding.variables))

--- a/service/grails-app/views/subscriptionAgreement/staticDroppedResources.gson
+++ b/service/grails-app/views/subscriptionAgreement/staticDroppedResources.gson
@@ -1,0 +1,1 @@
+json g.render (template: '/resource/resourceList', model: (binding.variables))

--- a/service/grails-app/views/subscriptionAgreement/staticFutureResources.gson
+++ b/service/grails-app/views/subscriptionAgreement/staticFutureResources.gson
@@ -1,0 +1,1 @@
+json g.render (template: '/resource/resourceList', model: (binding.variables))

--- a/service/grails-app/views/subscriptionAgreement/staticResources copy.gson
+++ b/service/grails-app/views/subscriptionAgreement/staticResources copy.gson
@@ -1,0 +1,1 @@
+json g.render (template: '/resource/resourceList', model: (binding.variables))


### PR DESCRIPTION
feat: Direct resources on an agreement

Added new "static" endpoints for fetching resources on an agreement directly via HQL, which do not include PTI links

Added new minimalView paramter to endpoints going through ermResource view file, which when the class is a PCI will refer instead to a minimalised PCI view file, cutting time off render.

ERM-3187