### PR TITLE
fix: Enrich Title

### DIFF
--- a/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/BaseTIRS.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/BaseTIRS.groovy
@@ -1,5 +1,7 @@
 package org.olf.dataimport.internal.titleInstanceResolvers
 
+import com.k_int.web.toolkit.refdata.RefdataValue
+
 import org.olf.IdentifierService
 
 import org.olf.dataimport.internal.PackageContentImpl
@@ -120,7 +122,7 @@ abstract class BaseTIRS implements TitleInstanceResolverService {
       * If the "Authoritative" publication type is not equal to whatever mad value a remote site has sent then
       * replace the authortiative value with the one sent?
       */
-      if (title.publicationType?.value != citation.instancePublicationMedia) {
+      if (title.publicationType?.value != RefdataValue.normValue(citation.instancePublicationMedia)) {
         if (citation.instancePublicationMedia) {
           title.publicationTypeFromString = citation.instancePublicationMedia
         } else {


### PR DESCRIPTION
BaseTIRS enrich title previously checked whether any changes had occurred before saving a TitleInstance. However it was checking eg "book" against "Book", so would _always_ trigger a save.