### PR TITLE
ERM-3254: With WorkSourceIDTIRS for GOKb we see "Field error in object" errors

### DIFF
--- a/service/grails-app/conf/logback-development.xml
+++ b/service/grails-app/conf/logback-development.xml
@@ -36,8 +36,6 @@
     <level value="DEBUG" />
   </logger>
   
-  
-  
   <logger name="org.springframework.jdbc.support" >
     <level value="ERROR" />
   </logger>
@@ -85,6 +83,11 @@
 
   <logger name="com.k_int.web.toolkit">
     <level value="DEBUG" />
+  </logger>
+
+  <logger name="com.k_int.web.toolkit.refdata.GrailsDomainRefdataHelpers">
+    <!-- Set to INFO to see logs like TitleInstance.setTypeFromString ( 'monograph' ) -->
+    <level value="ERROR" />
   </logger>
 
   <if condition='isDefined("grails.util.BuildSettings.TARGET_DIR")'>

--- a/service/grails-app/services/org/olf/TitleEnricherService.groovy
+++ b/service/grails-app/services/org/olf/TitleEnricherService.groovy
@@ -14,7 +14,7 @@ class TitleEnricherService {
   public static final ThreadLocal<Set> enrichedIds = new ThreadLocal<Set>()
 
   public void secondaryEnrichment(RemoteKB kb, String sourceIdentifier, String ermIdentifier) {
-    log.debug("TitleEnricherService::secondaryEnrichment called for title with source identifier: ${sourceIdentifier}, erm identifier: ${ermIdentifier} and RemoteKb: ${kb.name}")
+    //log.debug("TitleEnricherService::secondaryEnrichment called for title with source identifier: ${sourceIdentifier}, erm identifier: ${ermIdentifier} and RemoteKb: ${kb.name}")
     // Check for existence of sourceIdentifier. LOCAL source imports will pass null here.
     if (sourceIdentifier) {
 

--- a/service/grails-app/services/org/olf/TitleIngestService.groovy
+++ b/service/grails-app/services/org/olf/TitleIngestService.groovy
@@ -77,7 +77,8 @@ class TitleIngestService implements DataBinder {
     try {
       titleId = titleInstanceResolverService.resolve(pc, trustedSourceTI)
     } catch (Exception e){
-      log.error("Error resolving title (${pc.title}) with identifiers ${pc.instanceIdentifiers}, skipping. ${e.message}", e)
+      log.error("Error resolving title (${pc.title}) with identifiers ${pc.instanceIdentifiers}, skipping. ${e.message}")
+      // TODO consider turning these on by default for developers, perhaps in TRACE or likewise?
       //e.printStackTrace();
       return result
     }

--- a/service/grails-app/services/org/olf/TitleIngestService.groovy
+++ b/service/grails-app/services/org/olf/TitleIngestService.groovy
@@ -77,7 +77,7 @@ class TitleIngestService implements DataBinder {
     try {
       titleId = titleInstanceResolverService.resolve(pc, trustedSourceTI)
     } catch (Exception e){
-      log.error("Error resolving title (${pc.title}) with identifiers ${pc.instanceIdentifiers}, skipping. ${e.message}")
+      log.error("Error resolving title (${pc.title}) with identifiers ${pc.instanceIdentifiers}, skipping. ${e.message}", e)
       //e.printStackTrace();
       return result
     }

--- a/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/BaseTIRS.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/BaseTIRS.groovy
@@ -191,7 +191,7 @@ abstract class BaseTIRS implements TitleInstanceResolverService {
   // Different TIRS implementations will have different workflows with identifiers, but the vast majority of the creation will be the same
   // We assume that the incoming citation already has split ids and siblingIds
   protected TitleInstance createNewTitleInstanceWithoutIdentifiers(final ContentItemSchema citation, String workId = null) {
-    Work work = workId ? Work.get(workId) : null;
+    Work work = workId ? Work.get(workId) as Work : null;
     TitleInstance result = null
 
     // Ian: adding this - Attempt to make sense of the instanceMedia value we have been passed

--- a/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/WorkSourceIdentifierTIRSImpl.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/WorkSourceIdentifierTIRSImpl.groovy
@@ -142,10 +142,11 @@ class WorkSourceIdentifierTIRSImpl extends IdFirstTIRSImpl implements DataBinder
       tiId = super.resolve(citation, false);
     } catch (TIRSException tirsException) {
       // We treat a multiple title match here as NBD and move onto creation
-      // Any other TIRSExceptions are legitimate concerns and we should rethrow
-      if (
-        tirsException.code != TIRSException.MULTIPLE_TITLE_MATCHES
-      ) {
+      if (tirsException.code == TIRSException.MULTIPLE_TITLE_MATCHES) {
+        // Logging out where we hit this so we can potentially make decisions from the logs
+        log.debug("MULTIPLE_TITLE_MATCHES in IdFirstTIRS. Creating new TitleInstance (${tirsException.message})")
+      } else {
+        // Any other TIRSExceptions are legitimate concerns and we should rethrow
         throw new TIRSException(tirsException.message, tirsException.code);
       }
     } //Dont catch any other exception, those are legitimate reasons to stop

--- a/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/WorkSourceIdentifierTIRSImpl.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/WorkSourceIdentifierTIRSImpl.groovy
@@ -191,7 +191,9 @@ class WorkSourceIdentifierTIRSImpl extends IdFirstTIRSImpl implements DataBinder
             status: IdentifierOccurrence.lookupOrCreateStatus('approved')
           ])
           work.setSourceIdentifier(sourceIdentifier);
-          work.save(failOnError: true);
+          // FIXME make decision here either way
+          //work.save(failOnError: true, flush:true); // Flushing this is necessary for sibling wrangling, since they each take place in a new session
+          work.save(failOnError: true); // We removed the withNewSession -- see if it works
 
           // At this point we are assuming this TI is the right one, allow metadata updates
           checkForEnrichment(tiId, citation, true);
@@ -373,7 +375,8 @@ class WorkSourceIdentifierTIRSImpl extends IdFirstTIRSImpl implements DataBinder
       // Not really sure on the nuance here, but prevents HibernateAccessException whilst
       // Still ensuring that each directMatch has the DB changes from the previous citation
       // in place?
-      TitleInstance.withNewSession {
+      // FIXME do we still need this withNewSession?
+      //TitleInstance.withNewSession {
         // Match sibling citation to siblings already on the work (ONLY looking at approved identifiers)
         List<String> matchedSiblings = directMatch(sibling_citation.instanceIdentifiers, workId, 'print');
 
@@ -413,7 +416,7 @@ class WorkSourceIdentifierTIRSImpl extends IdFirstTIRSImpl implements DataBinder
             }
             break;
         }
-      }
+      //}
     }
 
     /* Now all sibling_citations exist as expected on the work.

--- a/service/src/main/okapi/tenant/sample_data/_data.groovy
+++ b/service/src/main/okapi/tenant/sample_data/_data.groovy
@@ -21,7 +21,7 @@ RemoteKB.findByName('GOKb_TEST') ?: (new RemoteKB(
     uri:'https://gokb.org/gokb/oai/index',
     fullPrefix:'gokb',
     rectype: RemoteKB.RECTYPE_PACKAGE,
-    active:Boolean.FALSE,
+    active:Boolean.TRUE,
     supportsHarvesting:true,
     activationEnabled:false
 ).save(failOnError:true)) */


### PR DESCRIPTION
Tweaked IDFirstTIRS
- Each sibling creation now does not happen in its own session, allowing any changes to the Work up above to be present for each sibling.
- Fixed issue where attempting to create a TIRS exception would instead throw an exception because String does not have an id... whoops...
- Fixed issue where a certain fallback branch still used TitleInstance instead of String (TitleInstance id)
- Improved logging:
  - IdFirstTIRS now explains where each match came from (class one vs sibling vs fuzzy title)
  - Turned off log debug in TitleEnricherService, since it _never_ actually does work nowadays
  - Turned off GrailsDomainRefdataHelper logging for developers by default, as it clogs up the logs something fierce. Can be turned back by setting back to INFO or above.