### PR TITLE
ERM-3225: Upgrade commons-fileupload from 1.4 to 1.5 fixing FileUpload DoS CVE-2023-24998

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -153,7 +153,6 @@ dependencies {
 
   implementation 'uk.co.cacoethes:groovy-handlebars-engine:0.2'
   implementation 'com.github.jknack:handlebars-helpers:4.3.1'
-  implementation 'commons-fileupload:commons-fileupload:1.4'
 
   implementation 'com.github.zafarkhaja:java-semver:0.9.0'
   implementation 'org.z3950.zing:cql-java:1.13'


### PR DESCRIPTION
build: removed direct commons fileupload dep

Removed dependency that AFAICS we're not using. It will still be pulled in (At a higher version) as part of grails, and we're using our own homebrewed fileUpload service anyway, so this shouldn't impact anything at all

ERM-3225