### PR TITLE
chore: Small tweaks to github actions

### DIFF
--- a/.github/workflows/int-tests.yml
+++ b/.github/workflows/int-tests.yml
@@ -35,15 +35,10 @@ jobs:
     needs: [work-source-identifier-tirs-tests, id-first-tirs-tests, agreement-tests, string-template-tests, general-tests]
     runs-on: ubuntu-latest
     steps:
-      - name: 'setup directories to accept test results'
-        run: |
-          mkdir -p testLogs
       - name: 'download test results'
         uses: actions/download-artifact@v4
         with:
           path: testLogs
-      - name: Display structure of downloaded files
-        run: ls -R
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:

--- a/.github/workflows/int-tests.yml
+++ b/.github/workflows/int-tests.yml
@@ -37,36 +37,11 @@ jobs:
     steps:
       - name: 'setup directories to accept test results'
         run: |
-          mkdir -p testLogs/WorkSourceIdentifierTests
-          mkdir -p testLogs/IdFirstTests
-          mkdir -p testLogs/Agreements
-          mkdir -p testLogs/StringTemplate
-          mkdir -p testLogs/General
-      - name: 'download WorkSourceIdentifier test results'
+          mkdir -p testLogs
+      - name: 'download test results'
         uses: actions/download-artifact@v4
         with:
-          name: WorkSourceIdentifierTests
-          path: testLogs/WorkSourceIdentifierTests
-      - name: 'download IdFirst test results'
-        uses: actions/download-artifact@v4
-        with:
-          name: IdFirstTests
-          path: testLogs/IdFirstTests
-      - name: 'download Agreements test results'
-        uses: actions/download-artifact@v4
-        with:
-          name: Agreements
-          path: testLogs/Agreements
-      - name: 'download StringTemplate test results'
-        uses: actions/download-artifact@v4
-        with:
-          name: StringTemplate
-          path: testLogs/StringTemplate
-      - name: 'download General test results'
-        uses: actions/download-artifact@v4
-        with:
-          name: General
-          path: testLogs/General
+          path: testLogs
       - name: Display structure of downloaded files
         run: ls -R
       - name: Publish Test Results

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -206,9 +206,7 @@ bootRun {
 }
 
 integrationTest {
-  println("LOGDEBUG AVAILABLE PROCESSORS: ${Runtime.runtime.availableProcessors()}")
-  //maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
-  maxParallelForks = 4
+  maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 	jvmArgs(
     '-Xmx1592m',
     '-XX:ReservedCodeCacheSize=256m'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -206,8 +206,13 @@ bootRun {
 }
 
 integrationTest {
+  println("LOGDEBUG AVAILABLE PROCESSORS: ${Runtime.runtime.availableProcessors()}")
+  //maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+  maxParallelForks = 4
 	jvmArgs(
-    '-Xmx1592m')
+    '-Xmx1592m',
+    '-XX:ReservedCodeCacheSize=256m'
+  )
 }
 
 project.gradle.projectsEvaluated {


### PR DESCRIPTION
now should download all artifacts in one fell swoop, and should show up number of available processors