### PR TITLE
ERM-3281: Design and implement process to resolve eissn, pissn, eisbn and pisbn namespaces

### DIFF
--- a/service/grails-app/conf/application-dc.yml
+++ b/service/grails-app/conf/application-dc.yml
@@ -14,7 +14,7 @@ dataSource:
   logSql: false
   properties:
       jmxEnabled: false
-      maximumPoolSize: ${db.maxpoolsize:10}
+      maximumPoolSize: ${db.maxpoolsize:50}
       transactionIsolation: TRANSACTION_READ_COMMITTED
 
   hibernate:

--- a/service/grails-app/conf/application-rancher-desktop-db.yml
+++ b/service/grails-app/conf/application-rancher-desktop-db.yml
@@ -14,7 +14,7 @@ dataSource:
   logSql: false
   properties:
       jmxEnabled: false
-      maximumPoolSize: ${db.maxpoolsize:10}
+      maximumPoolSize: ${db.maxpoolsize:50}
       transactionIsolation: TRANSACTION_READ_COMMITTED
   hibernate:
     enable_lazy_load_no_trans: true

--- a/service/grails-app/domain/org/olf/kb/Identifier.groovy
+++ b/service/grails-app/domain/org/olf/kb/Identifier.groovy
@@ -32,5 +32,7 @@ public class Identifier implements MultiTenant<Identifier> {
              ns(nullable:false)
   }
 
-
+  String toString() {
+    "${ns.value}:${value}"
+  }
 }

--- a/service/grails-app/services/org/olf/IdentifierService.groovy
+++ b/service/grails-app/services/org/olf/IdentifierService.groovy
@@ -358,7 +358,7 @@ public class IdentifierService {
             default:
               // This shouldn't happen, give up
               throw new IdentifierException(
-                "fixEquivalentIds found multiple identifier occurrences for the same identifier/resource combination: ${prime_occurrence_candidates}",
+                "fixEquivalentIds found multiple identifier occurrences for the same identifier/resource combination: ${prime_occurrence_candidates.collect { it.id }}",
                 IdentifierException.FIX_IDENTIFIER_ERROR
               )
               break;

--- a/service/grails-app/services/org/olf/IdentifierService.groovy
+++ b/service/grails-app/services/org/olf/IdentifierService.groovy
@@ -287,7 +287,7 @@ public class IdentifierService {
     """.toString(), [equivalentIdentifierIds: equivalentIdentifierIds])
 
     // Logging here so we can get information about which ids are being equated as well as their ids in the DB
-    log.debug("fixEquivalentIds::(${equivalentIds.collect { "${it.ns.value}:${it.value}(${it.id})" }}, ${primeNamespace}, ${primeValue}, ${strictValueEquivalence})")
+    log.debug("fixEquivalentIds::(${equivalentIds.collect { "${it} (${it.id})" }}, ${primeNamespace}, ${primeValue}, ${strictValueEquivalence})")
 
     if (strictValueEquivalence) {
       // If we're protecting

--- a/service/grails-app/services/org/olf/IdentifierService.groovy
+++ b/service/grails-app/services/org/olf/IdentifierService.groovy
@@ -264,8 +264,6 @@ public class IdentifierService {
   ) {
     // Fetch this at the top so we aren't lookup-or-creating in a loop below.
     RefdataValue approvedStatus = lookupOrCreateStatus('approved');
-
-    log.debug("fixEquivalentIds::(${equivalentIdentifierIds}, ${primeNamespace}, ${primeValue}, ${strictValueEquivalence})")
     // Without primeNamespace, throw
     if (primeNamespace == null) {
       throw new IdentifierException(
@@ -287,6 +285,9 @@ public class IdentifierService {
       SELECT id FROM Identifier AS id
       WHERE id.id IN :equivalentIdentifierIds
     """.toString(), [equivalentIdentifierIds: equivalentIdentifierIds])
+
+    // Logging here so we can get information about which ids are being equated as well as their ids in the DB
+    log.debug("fixEquivalentIds::(${equivalentIds.collect { "${it.ns.value}:${it.value}(${it.id})" }}, ${primeNamespace}, ${primeValue}, ${strictValueEquivalence})")
 
     if (strictValueEquivalence) {
       // If we're protecting

--- a/service/grails-app/services/org/olf/IdentifierService.groovy
+++ b/service/grails-app/services/org/olf/IdentifierService.groovy
@@ -372,7 +372,6 @@ public class IdentifierService {
       }
     }
 
-    // TODO does primeIdentifier have an id if it didn't exist before?
     return primeIdentifier.id;
   }
 }

--- a/service/grails-app/services/org/olf/IdentifierService.groovy
+++ b/service/grails-app/services/org/olf/IdentifierService.groovy
@@ -192,8 +192,11 @@ public class IdentifierService {
     );
   }
 
-
   /*
+   * TODO Should probably integration test these methods
+   *
+   *
+   * ASSUMPTION -- Assumes context from calling code
    * This is where we can call the namespaceMapping function to ensure consistency in our DB
    */
   public IdentifierNamespace lookupOrCreateIdentifierNamespace(final String ns) {
@@ -201,6 +204,7 @@ public class IdentifierService {
   }
 
   /*
+   * ASSUMPTION -- Assumes context from calling code
    * Given an identifier { value:'1234-5678', namespace:'isbn' }
    * lookup or create an identifier in the DB to represent that info.
    */

--- a/service/grails-app/services/org/olf/IdentifierService.groovy
+++ b/service/grails-app/services/org/olf/IdentifierService.groovy
@@ -199,8 +199,8 @@ public class IdentifierService {
    * ASSUMPTION -- Assumes context from calling code
    * This is where we can call the namespaceMapping function to ensure consistency in our DB
    */
-  public IdentifierNamespace lookupOrCreateIdentifierNamespace(final String ns) {
-    IdentifierNamespace.findOrCreateByValue(namespaceMapping(ns)).save(failOnError:true)
+  public IdentifierNamespace lookupOrCreateIdentifierNamespace(final String ns, final boolean flush = false) {
+    IdentifierNamespace.findOrCreateByValue(namespaceMapping(ns)).save(failOnError:true, flush: flush)
   }
 
   /*
@@ -208,7 +208,7 @@ public class IdentifierService {
    * Given an identifier { value:'1234-5678', namespace:'isbn' }
    * lookup or create an identifier in the DB to represent that info.
    */
-  protected String lookupOrCreateIdentifier(final String value, final String namespace, boolean flush = true) {
+  public String lookupOrCreateIdentifier(final String value, final String namespace, final boolean flush = false) {
     String result = null;
 
     // Ensure we are looking up properly mapped namespace (pisbn -> isbn, etc)

--- a/service/grails-app/services/org/olf/IdentifierService.groovy
+++ b/service/grails-app/services/org/olf/IdentifierService.groovy
@@ -224,7 +224,7 @@ public class IdentifierService {
         break;
       default:
         throw new IdentifierException(
-          "Matched multiple identifiers for ${id}",
+          "Matched multiple identifiers for ${namespace}:${value}",
           IdentifierException.MULTIPLE_IDENTIFIER_MATCHES
         );
         break;

--- a/service/src/integration-test/groovy/org/olf/Agreements/AgreementLifecycleSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/Agreements/AgreementLifecycleSpec.groovy
@@ -375,7 +375,7 @@ class AgreementLifecycleSpec extends BaseSpec {
     when: 'We upload a file'
       log.debug("Create new package with tenant ${tenantId}");
 
-      Tenants.withId(OkapiTenantResolver.getTenantSchemaName( tenantId )) {
+      withTenant {
         FileUpload fu = null;
 
         FileUpload.withTransaction { status ->
@@ -398,7 +398,7 @@ class AgreementLifecycleSpec extends BaseSpec {
     when: 'We upload a file and then clone it'
       log.debug("Create new package with tenant ${tenantId}");
 
-      Tenants.withId(OkapiTenantResolver.getTenantSchemaName( tenantId )) {
+      withTenant {
         FileUpload fu = null;
 
         FileUpload.withTransaction { status ->
@@ -425,7 +425,7 @@ class AgreementLifecycleSpec extends BaseSpec {
     when: 'We upload a file and then clone it'
       log.debug("Create new package with tenant ${tenantId}");
 
-      Tenants.withId(OkapiTenantResolver.getTenantSchemaName( tenantId )) {
+      withTenant {
         String fu_id = null;
 
         FileUpload.withTransaction { status ->

--- a/service/src/integration-test/groovy/org/olf/BaseSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/BaseSpec.groovy
@@ -69,6 +69,22 @@ abstract class BaseSpec extends HttpSpec {
     currentTenant.toLowerCase()
   }
 
+  @Ignore
+  def withTenant(Closure c) {
+    Tenants.withId(OkapiTenantResolver.getTenantSchemaName( tenantId )) {
+      c.call()
+    }
+  }
+
+  @Ignore
+  def withTenantNewTransaction(Closure c) {
+    withTenant {
+      GormUtils.withNewTransaction {
+        c.call()
+      }
+    }
+  }
+
   void 'Pre purge test tenant'() {
     boolean resp = false
     log.debug("Pre purge tenant");
@@ -155,7 +171,7 @@ abstract class BaseSpec extends HttpSpec {
   def importPackageFromMapViaService(Map package_data) {
     Map result = [:]
     log.debug("Create new package with tenant ${tenantId}");
-    Tenants.withId(OkapiTenantResolver.getTenantSchemaName( tenantId )) {
+    withTenant {
       Pkg.withTransaction { status ->
         result = importService.importFromFile( package_data )
         // This logging causes issues with transactional test methods in WorkSourceIdentifierTIRSSpec -- commenting for now

--- a/service/src/integration-test/groovy/org/olf/BaseSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/BaseSpec.groovy
@@ -45,6 +45,7 @@ abstract class BaseSpec extends HttpSpec {
   static String WORK_SOURCE_TIRS = "${baseTIRSPath}.WorkSourceIdentifierTIRSImpl"
 
   def importService
+  def identifierService
 
   def setupSpec() {
     httpClientConfig = {

--- a/service/src/integration-test/groovy/org/olf/BaseSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/BaseSpec.groovy
@@ -10,6 +10,8 @@ import org.olf.kb.TitleInstance
 
 import grails.gorm.multitenancy.Tenants
 
+import com.k_int.web.toolkit.utils.GormUtils
+
 import groovyx.net.http.HttpException
 import spock.lang.Stepwise
 import spock.lang.Ignore

--- a/service/src/integration-test/groovy/org/olf/General/IdentifierServiceSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/General/IdentifierServiceSpec.groovy
@@ -165,6 +165,7 @@ class IdentifierServiceSpec extends BaseSpec {
 
       assert ios.size() == 3;
       assert ios.every { io -> io.identifier.id == primeId.id };
+      // TODO test prime occurrence wrangling
    /*  cleanup:
       withTenantNewTransaction {
         // Remove all IdentifierOccurrences and ErmTitleLists

--- a/service/src/integration-test/groovy/org/olf/General/IdentifierServiceSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/General/IdentifierServiceSpec.groovy
@@ -41,8 +41,8 @@ class IdentifierServiceSpec extends BaseSpec {
     'test-1x': ['a'],
     'test-errors': ['id1', 'id2', 'id3'],
     'test-errors-x': ['id1'],
-    'test-2': ['a', 'b', 'c', 'c2'],
-    'test-3': ['wibble']
+    'test-2': ['a'],
+    'test-2x': ['a']
   ]
 
   @Shared
@@ -53,6 +53,18 @@ class IdentifierServiceSpec extends BaseSpec {
 
   @Shared
   Set<Identifier> identifierObjectsInSystem = new HashSet();
+
+  @Ignore
+  void clearUpTitleListsAndIdentifierOccurrences() {
+    // Remove all IdentifierOccurrences and ErmTitleLists
+    IdentifierOccurrence.executeUpdate("""
+      DELETE FROM IdentifierOccurrence AS io
+    """.toString())
+
+    ErmTitleList.executeUpdate("""
+      DELETE FROM ErmTitleList AS etl
+    """.toString())
+  }
 
   @Ignore
   void lookupIdentifiersInSystem() {
@@ -170,14 +182,7 @@ class IdentifierServiceSpec extends BaseSpec {
       // TODO test prime occurrence wrangling
     cleanup:
       withTenantNewTransaction {
-        // Remove all IdentifierOccurrences and ErmTitleLists
-        IdentifierOccurrence.executeUpdate("""
-          DELETE FROM IdentifierOccurrence AS io
-        """.toString())
-
-        ErmTitleList.executeUpdate("""
-          DELETE FROM ErmTitleList AS etl
-        """.toString())
+        clearUpTitleListsAndIdentifierOccurrences()
       }
   }
 
@@ -268,5 +273,216 @@ class IdentifierServiceSpec extends BaseSpec {
     then: 'The expected Exception is thrown'
       assert code == IdentifierException.FIX_IDENTIFIER_ERROR
       assert message.startsWith("fixEquivalentIds found multiple identifier occurrences for the same identifier/resource combination: ")
+    cleanup:
+      withTenantNewTransaction {
+        clearUpTitleListsAndIdentifierOccurrences()
+      }
+  }
+
+  def 'Fix equivalent ids occurrence wrangling' () {
+    // Test that the management where occurrences already exist is correct
+    when: 'We set up 4 resources and 6 identifier occurrences'
+      ErmTitleList mockTitleList1;
+      ErmTitleList mockTitleList2;
+      ErmTitleList mockTitleList3;
+      ErmTitleList mockTitleList4;
+      ErmTitleList mockTitleList5;
+      ErmTitleList mockTitleList6;
+
+      IdentifierOccurrence io1;
+      IdentifierOccurrence io2;
+      IdentifierOccurrence io3;
+      IdentifierOccurrence io4;
+      IdentifierOccurrence io5;
+      IdentifierOccurrence io6;
+      IdentifierOccurrence io7;
+      IdentifierOccurrence io8;
+      IdentifierOccurrence io9;
+      IdentifierOccurrence io10;
+      
+
+      withTenantNewTransaction {
+        mockTitleList1 = new ErmTitleList().save(failOnError: true);
+        mockTitleList2 = new ErmTitleList().save(failOnError: true);
+        mockTitleList3 = new ErmTitleList().save(failOnError: true);
+        mockTitleList4 = new ErmTitleList().save(failOnError: true);
+        mockTitleList5 = new ErmTitleList().save(failOnError: true);
+        mockTitleList6 = new ErmTitleList().save(failOnError: true);
+
+        io1 = new IdentifierOccurrence(
+          identifier: identifierObjectsInSystem.find { id -> id.ns.value == 'test-2' },
+          resource: mockTitleList1,
+          status: IdentifierOccurrence.lookupOrCreateStatus('approved')
+        ).save(failOnError: true);
+
+        io2 = new IdentifierOccurrence(
+          identifier: identifierObjectsInSystem.find { id -> id.ns.value == 'test-2x' && id.value == 'a' },
+          resource: mockTitleList1,
+          status: IdentifierOccurrence.lookupOrCreateStatus('error')
+        ).save(failOnError: true);
+
+        io3 = new IdentifierOccurrence(
+          identifier: identifierObjectsInSystem.find { id -> id.ns.value == 'test-2' },
+          resource: mockTitleList2,
+          status: IdentifierOccurrence.lookupOrCreateStatus('approved')
+        ).save(failOnError: true);
+
+        io4 = new IdentifierOccurrence(
+          identifier: identifierObjectsInSystem.find { id -> id.ns.value == 'test-2x' },
+          resource: mockTitleList3,
+          status: IdentifierOccurrence.lookupOrCreateStatus('error')
+        ).save(failOnError: true);
+
+        io5 = new IdentifierOccurrence(
+          identifier: identifierObjectsInSystem.find { id -> id.ns.value == 'test-2' },
+          resource: mockTitleList4,
+          status: IdentifierOccurrence.lookupOrCreateStatus('error')
+        ).save(failOnError: true);
+
+        io6 = new IdentifierOccurrence(
+          identifier: identifierObjectsInSystem.find { id -> id.ns.value == 'test-2x' },
+          resource: mockTitleList4,
+          status: IdentifierOccurrence.lookupOrCreateStatus('approved')
+        ).save(failOnError: true);
+
+        io7 = new IdentifierOccurrence(
+          identifier: identifierObjectsInSystem.find { id -> id.ns.value == 'test-2' },
+          resource: mockTitleList5,
+          status: IdentifierOccurrence.lookupOrCreateStatus('error')
+        ).save(failOnError: true);
+
+        io8 = new IdentifierOccurrence(
+          identifier: identifierObjectsInSystem.find { id -> id.ns.value == 'test-2x' },
+          resource: mockTitleList5,
+          status: IdentifierOccurrence.lookupOrCreateStatus('error')
+        ).save(failOnError: true);
+
+        io9 = new IdentifierOccurrence(
+          identifier: identifierObjectsInSystem.find { id -> id.ns.value == 'test-2' },
+          resource: mockTitleList6,
+          status: IdentifierOccurrence.lookupOrCreateStatus('approved')
+        ).save(failOnError: true);
+
+        io10 = new IdentifierOccurrence(
+          identifier: identifierObjectsInSystem.find { id -> id.ns.value == 'test-2x' },
+          resource: mockTitleList6,
+          status: IdentifierOccurrence.lookupOrCreateStatus('approved')
+        ).save(failOnError: true);
+      }
+    then: 'All good'
+      noExceptionThrown()
+    when: 'We subsequently look up domain objects'
+      List<IdentifierOccurrence> ios;
+      List<ErmTitleList> etls;
+      withTenant {
+        ios = IdentifierOccurrence.executeQuery("""
+          SELECT io FROM IdentifierOccurrence AS io
+        """)
+
+        etls = ErmTitleList.executeQuery("""
+          SELECT etl FROM ErmTitleList AS etl
+        """)
+      }
+    then: 'We have expected numbers'
+      assert etls.size() == 6;
+      assert ios.size() == 10;
+      assert ios.findAll { io -> io.status.value == 'approved' }.size() == 5;
+      assert ios.findAll { io -> io.status.value == 'error' }.size() == 5;
+
+      assert ios.findAll { io -> io.identifier.ns.value == 'test-2' }.size() == 5;
+      assert ios.findAll { io -> io.identifier.ns.value == 'test-2x' }.size() == 5;
+
+    then: 'Test case 1 (Prime occurrence approved and equivalent occurrence error) set up correctly'
+      assert ios.findAll { io -> io.identifier.ns.value == 'test-2' && io.resource.id == mockTitleList1.id }.size() == 1;
+      assert ios.find { io -> io.identifier.ns.value == 'test-2' && io.resource.id == mockTitleList1.id }.status.value == 'approved'
+      assert ios.findAll { io -> io.identifier.ns.value == 'test-2x' && io.resource.id == mockTitleList1.id }.size() == 1;
+      assert ios.find { io -> io.identifier.ns.value == 'test-2x' && io.resource.id == mockTitleList1.id }.status.value == 'error'
+    then: 'Test case 2 (Prime occurrence only) set up correctly'
+      assert ios.findAll { io -> io.identifier.ns.value == 'test-2' && io.resource.id == mockTitleList2.id }.size() == 1;
+      assert ios.find { io -> io.identifier.ns.value == 'test-2' && io.resource.id == mockTitleList2.id }.status.value == 'approved'
+      assert ios.findAll { io -> io.identifier.ns.value == 'test-2x' && io.resource.id == mockTitleList2.id }.size() == 0;
+    then: 'Test case 3 (Equivalent occurrence only) set up correctly'
+      assert ios.findAll { io -> io.identifier.ns.value == 'test-2' && io.resource.id == mockTitleList3.id }.size() == 0;
+      assert ios.findAll { io -> io.identifier.ns.value == 'test-2x' && io.resource.id == mockTitleList3.id }.size() == 1;
+      assert ios.find { io -> io.identifier.ns.value == 'test-2x' && io.resource.id == mockTitleList3.id }.status.value == 'error'
+    then: 'Test case 4 (Prime occurrence error and equivalent occurrence approved) set up correctly'
+      assert ios.findAll { io -> io.identifier.ns.value == 'test-2' && io.resource.id == mockTitleList4.id }.size() == 1;
+      assert ios.find { io -> io.identifier.ns.value == 'test-2' && io.resource.id == mockTitleList4.id }.status.value == 'error'
+      assert ios.findAll { io -> io.identifier.ns.value == 'test-2x' && io.resource.id == mockTitleList4.id }.size() == 1;
+      assert ios.find { io -> io.identifier.ns.value == 'test-2x' && io.resource.id == mockTitleList4.id }.status.value == 'approved'
+    then: 'Test case 5 (Prime occurrence error and equivalent occurrence error) set up correctly'
+      assert ios.findAll { io -> io.identifier.ns.value == 'test-2' && io.resource.id == mockTitleList5.id }.size() == 1;
+      assert ios.find { io -> io.identifier.ns.value == 'test-2' && io.resource.id == mockTitleList5.id }.status.value == 'error'
+      assert ios.findAll { io -> io.identifier.ns.value == 'test-2x' && io.resource.id == mockTitleList5.id }.size() == 1;
+      assert ios.find { io -> io.identifier.ns.value == 'test-2x' && io.resource.id == mockTitleList5.id }.status.value == 'error'
+    then: 'Test case 6 (Prime occurrence approved and equivalent occurrence approved) set up correctly'
+      assert ios.findAll { io -> io.identifier.ns.value == 'test-2' && io.resource.id == mockTitleList6.id }.size() == 1;
+      assert ios.find { io -> io.identifier.ns.value == 'test-2' && io.resource.id == mockTitleList6.id }.status.value == 'approved'
+      assert ios.findAll { io -> io.identifier.ns.value == 'test-2x' && io.resource.id == mockTitleList6.id }.size() == 1;
+      assert ios.find { io -> io.identifier.ns.value == 'test-2x' && io.resource.id == mockTitleList6.id }.status.value == 'approved'
+    when: 'We merge test-2:a and test-2x:a we get the expected behaviour'
+      withTenantNewTransaction {
+        identifierService.fixEquivalentIds(
+          identifierObjectsInSystem.findAll { id ->
+            id.ns.value == 'test-2' ||
+            id.ns.value == 'test-2x'
+          }.collect { it.id }, // Send in the ids for the method to work with
+          'test-2'
+        )
+      }
+    then: 'All good'
+      noExceptionThrown();
+    when: 'We subsequently look up domain objects'
+      withTenant {
+        ios = IdentifierOccurrence.executeQuery("""
+          SELECT io FROM IdentifierOccurrence AS io
+        """)
+
+        etls = ErmTitleList.executeQuery("""
+          SELECT etl FROM ErmTitleList AS etl
+        """)
+      }
+    then: 'We have expected numbers'
+      assert etls.size() == 6;
+      assert ios.size() == 6;
+      
+      println(ios.collect { io -> "IO id: ${io.id}, resource: ${io.resource.id}" })
+
+      assert ios.findAll { io -> io.identifier.ns.value == 'test-2' }.size() == 6;
+      assert ios.findAll { io -> io.identifier.ns.value == 'test-2x' }.size() == 0;
+    then: 'TC1 has kept primeOccurrence'
+      assert ios.findAll { io -> io.resource.id == mockTitleList1.id }.size() == 1;
+      assert ios.find { io -> io.resource.id == mockTitleList1.id }.id == io1.id;
+    then: 'TC1 has remained approved'
+      assert ios.find { io -> io.resource.id == mockTitleList1.id }.status.value == 'approved';
+    then: 'TC2 has kept primeOccurrence'
+      assert ios.findAll { io -> io.resource.id == mockTitleList2.id }.size() == 1;
+      assert ios.find { io -> io.resource.id == mockTitleList2.id }.id == io3.id;
+    then: 'TC2 has remained approved'
+      assert ios.find { io -> io.resource.id == mockTitleList2.id }.status.value == 'approved';
+    then: 'TC3 has new primeOccurrence'
+      assert ios.findAll { io -> io.resource.id == mockTitleList3.id }.size() == 1;
+      assert ios.find { io -> io.resource.id == mockTitleList3.id }.id == io4.id;
+    then: 'TC3 has remained error'
+      assert ios.find { io -> io.resource.id == mockTitleList3.id }.status.value == 'error';
+    then: 'TC4 has kept primeOccurrence'
+      assert ios.findAll { io -> io.resource.id == mockTitleList4.id }.size() == 1;
+      assert ios.find { io -> io.resource.id == mockTitleList4.id }.id == io5.id;
+    then: 'TC4 has become approved'
+      assert ios.find { io -> io.resource.id == mockTitleList4.id }.status.value == 'approved';
+    then: 'TC5 has kept primeOccurrence'
+      assert ios.findAll { io -> io.resource.id == mockTitleList5.id }.size() == 1;
+      assert ios.find { io -> io.resource.id == mockTitleList5.id }.id == io7.id;
+    then: 'TC5 has remained error'
+      assert ios.find { io -> io.resource.id == mockTitleList5.id }.status.value == 'error';
+    then: 'TC6 has kept primeOccurrence'
+      assert ios.findAll { io -> io.resource.id == mockTitleList6.id }.size() == 1;
+      assert ios.find { io -> io.resource.id == mockTitleList6.id }.id == io9.id;
+    then: 'TC6 has remained approved'
+      assert ios.find { io -> io.resource.id == mockTitleList6.id }.status.value == 'approved';
+    cleanup:
+      withTenantNewTransaction {
+        clearUpTitleListsAndIdentifierOccurrences()
+      }
   }
 }

--- a/service/src/integration-test/groovy/org/olf/General/IdentifierServiceSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/General/IdentifierServiceSpec.groovy
@@ -21,7 +21,6 @@ import grails.testing.mixin.integration.Integration
 
 // Utilities
 import com.k_int.okapi.OkapiTenantResolver
-import com.k_int.web.toolkit.utils.GormUtils
 
 import grails.gorm.multitenancy.Tenants
 import grails.gorm.transactions.Transactional
@@ -37,13 +36,31 @@ class IdentifierServiceSpec extends BaseSpec {
   // Map from namespace -> list of identifiers we're going to set up
   @Shared
   Map<String, List<String>> bootstrappedIdentifiers = [
-    'test': ['a', 'b', 'c', 'd'],
+    'test': ['a'],
+    'test-1': ['a'],
+    'test-1x': ['a'],
     'test-2': ['a', 'b', 'c', 'c2'],
     'test-3': ['wibble']
   ]
 
   @Shared
   Set<String> expectedIdentifiersInSystem = new HashSet();
+
+  @Shared
+  Set<String> identifiersInSystem = new HashSet();
+
+  @Shared
+  Set<Identifier> identifierObjectsInSystem = new HashSet();
+
+  @Ignore
+  void lookupIdentifiersInSystem() {
+    List<Identifier> identifiers = Identifier.executeQuery("""
+        SELECT iden FROM Identifier AS iden
+      """)
+
+    identifiersInSystem = identifiers.collect { "${it.ns.value}:${it.value}" } as Set;
+    identifierObjectsInSystem = identifiers as Set;
+  }
   
   def 'Creating identifiers works as expected' () {
     when: 'We set up a bunch of identifiers';
@@ -62,24 +79,98 @@ class IdentifierServiceSpec extends BaseSpec {
     then: 'All good'
       noExceptionThrown()
     when: 'We subsequently look up identifiers'
-      List<Identifier> identifiers;
-
       withTenant {
-        identifiers = Identifier.executeQuery("""
-          SELECT iden FROM Identifier AS iden
-        """)
+        lookupIdentifiersInSystem();
       }
-
-      Set<String> identifiersInSystem = identifiers.collect { "${it.ns.value}:${it.value}" } as Set
     then: 'We see the expected identifiers in the system';
       assert identifiersInSystem.equals(expectedIdentifiersInSystem);
   }
 
-  /* def 'Fix equivalent ids where prime identifier doesn\'t exist' () {
-    when: 'We set up a bunch of IdentifierOccurrences for Identifiers in the system';
-      withTenant {
+  def 'Fix equivalent ids' () {
+    when: 'We set up a bunch of IdentifierOccurrence for Identifiers in the system';
+      withTenantNewTransaction {
         ErmTitleList mockTitleList1 = new ErmTitleList().save(failOnError: true);
         ErmTitleList mockTitleList2 = new ErmTitleList().save(failOnError: true);
+        ErmTitleList mockTitleList3 = new ErmTitleList().save(failOnError: true);
+
+        IdentifierOccurrence io1 = new IdentifierOccurrence(
+          identifier: identifierObjectsInSystem.find { id -> id.ns.value == 'test' && id.value == 'a' },
+          resource: mockTitleList1,
+          status: IdentifierOccurrence.lookupOrCreateStatus('approved')
+        ).save(failOnError: true);
+
+        IdentifierOccurrence io2 = new IdentifierOccurrence(
+          identifier: identifierObjectsInSystem.find { id -> id.ns.value == 'test-1' && id.value == 'a' },
+          resource: mockTitleList2,
+          status: IdentifierOccurrence.lookupOrCreateStatus('error')
+        ).save(failOnError: true)
+
+        IdentifierOccurrence io3 = new IdentifierOccurrence(
+          identifier: identifierObjectsInSystem.find { id -> id.ns.value == 'test-1x' && id.value == 'a' },
+          resource: mockTitleList3,
+          status: IdentifierOccurrence.lookupOrCreateStatus('approved')
+        ).save(failOnError: true)
       }
-  } */
+    then: 'All good'
+      noExceptionThrown()
+    when: 'We lookup domain objects'
+      List<IdentifierOccurrence> ios;
+      List<ErmTitleList> etls;
+      withTenant {
+        ios = IdentifierOccurrence.executeQuery("""
+          SELECT io FROM IdentifierOccurrence AS io
+        """)
+
+        etls = ErmTitleList.executeQuery("""
+          SELECT etl FROM ErmTitleList AS etl
+        """)
+      }
+    then: 'We have what we expect'
+      assert etls.size() == 3;
+      assert ios.size() == 3;
+      assert ios.findAll { io -> io.identifier.ns.value == 'test' && io.identifier.value == 'a' }.size() == 1;
+      assert ios.findAll { io -> io.identifier.ns.value == 'test-1' && io.identifier.value == 'a' }.size() == 1;
+      assert ios.findAll { io -> io.identifier.ns.value == 'test-1x' && io.identifier.value == 'a' }.size() == 1;
+    when: 'We call fixEquivalentIds'
+      String primeIdId;
+      withTenantNewTransaction {
+        primeIdId = identifierService.fixEquivalentIds(
+          identifierObjectsInSystem.findAll { id ->
+            id.ns.value == 'test' ||
+            id.ns.value == 'test-1' ||
+            id.ns.value == 'test-1x'
+          }.collect { it.id }, // Send in the ids for the method to work with
+          'test'
+        )
+      }
+    then: 'All good'
+      noExceptionThrown();
+    when: 'We subsequently look up identifiers and identifierOccurrences'
+      Identifier primeId;
+      withTenant {
+        ios = IdentifierOccurrence.executeQuery("""
+          SELECT io FROM IdentifierOccurrence AS io
+        """)
+        primeId = identifierObjectsInSystem.find { id -> id.ns.value == 'test' && id.value == 'a' }
+
+        lookupIdentifiersInSystem();
+      }
+    then: 'We see that certain identifiers have merged together'
+      assert identifiersInSystem.find { id -> id == "test:a"} != null;
+      assert identifiersInSystem.find { id -> id == "test-1:a"} == null;
+      assert identifiersInSystem.find { id -> id == "test-1x:a"} == null;
+
+      assert primeId != null;
+      assert primeId.id == primeIdId;
+
+      assert ios.size() == 3;
+      assert ios.every { io -> io.identifier.id == primeId.id };
+   /*  cleanup:
+      withTenantNewTransaction {
+        // Remove all IdentifierOccurrences and ErmTitleLists
+        ErmTitleList.executeUpdate("""
+          DELETE FROM ErmTitleList AS etl
+        """.toString())
+      } */
+  }
 }

--- a/service/src/integration-test/groovy/org/olf/General/IdentifierServiceSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/General/IdentifierServiceSpec.groovy
@@ -72,7 +72,7 @@ class IdentifierServiceSpec extends BaseSpec {
         SELECT iden FROM Identifier AS iden
       """)
 
-    identifiersInSystem = identifiers.collect { "${it.ns.value}:${it.value}" } as Set;
+    identifiersInSystem = identifiers.collect { "${it}" } as Set;
     identifierObjectsInSystem = identifiers as Set;
   }
   

--- a/service/src/integration-test/groovy/org/olf/General/IdentifierServiceSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/General/IdentifierServiceSpec.groovy
@@ -1,0 +1,85 @@
+package org.olf.General
+
+// Services
+import org.olf.IdentifierService
+
+// Domain classes
+import org.olf.kb.Identifier
+import org.olf.kb.IdentifierOccurrence
+import org.olf.kb.IdentifierNamespace
+import org.olf.kb.ErmTitleList
+
+// Others
+import org.olf.kb.IdentifierException
+
+// Test classes
+import org.olf.BaseSpec
+
+// Testing classes
+import spock.lang.*
+import grails.testing.mixin.integration.Integration
+
+// Utilities
+import com.k_int.okapi.OkapiTenantResolver
+import com.k_int.web.toolkit.utils.GormUtils
+
+import grails.gorm.multitenancy.Tenants
+import grails.gorm.transactions.Transactional
+import org.springframework.transaction.annotation.Propagation
+import groovy.util.logging.Slf4j
+
+@Integration
+@Stepwise
+@Slf4j
+class IdentifierServiceSpec extends BaseSpec {
+  def identifierService;
+  
+  // Map from namespace -> list of identifiers we're going to set up
+  @Shared
+  Map<String, List<String>> bootstrappedIdentifiers = [
+    'test': ['a', 'b', 'c', 'd'],
+    'test-2': ['a', 'b', 'c', 'c2'],
+    'test-3': ['wibble']
+  ]
+
+  @Shared
+  Set<String> expectedIdentifiersInSystem = new HashSet();
+  
+  def 'Creating identifiers works as expected' () {
+    when: 'We set up a bunch of identifiers';
+      // I don't love doing this manually but it works...
+      withTenantNewTransaction {
+        bootstrappedIdentifiers.keySet().each { idns ->
+          bootstrappedIdentifiers[idns].each { val ->
+            identifierService.lookupOrCreateIdentifier(val, idns)
+          }
+        }
+      }
+          
+      bootstrappedIdentifiers.keySet().each { idns ->
+        expectedIdentifiersInSystem.addAll(bootstrappedIdentifiers[idns].collect{ "${idns}:${it}" })
+      }
+    then: 'All good'
+      noExceptionThrown()
+    when: 'We subsequently look up identifiers'
+      List<Identifier> identifiers;
+
+      withTenant {
+        identifiers = Identifier.executeQuery("""
+          SELECT iden FROM Identifier AS iden
+        """)
+      }
+
+      Set<String> identifiersInSystem = identifiers.collect { "${it.ns.value}:${it.value}" } as Set
+    then: 'We see the expected identifiers in the system';
+      assert identifiersInSystem.equals(expectedIdentifiersInSystem);
+  }
+
+  /* def 'Fix equivalent ids where prime identifier doesn\'t exist' () {
+    when: 'We set up a bunch of IdentifierOccurrences for Identifiers in the system';
+      withTenant {
+        ErmTitleList mockTitleList1 = new ErmTitleList().save(failOnError: true);
+        ErmTitleList mockTitleList2 = new ErmTitleList().save(failOnError: true);
+      }
+  } */
+}

--- a/service/src/integration-test/groovy/org/olf/General/PlatformSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/General/PlatformSpec.groovy
@@ -19,7 +19,7 @@ class PlatformSpec extends BaseSpec {
     when: 'Resolve platform from url #platformUrl'
     
       def platform = null
-      Tenants.withId(OkapiTenantResolver.getTenantSchemaName( tenantId )) {
+      withTenant {
         platform = Platform.resolve(platformUrl)
       }
 

--- a/service/src/integration-test/groovy/org/olf/General/TitleServiceSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/General/TitleServiceSpec.groovy
@@ -66,7 +66,7 @@ class TitleServiceSpec extends BaseSpec {
 
       // We are exercising the service directly, normally a transactional context will
       // be supplied by the HTTPRequest, but we fake it here to talk directly to the service
-      Tenants.withId(OkapiTenantResolver.getTenantSchemaName( tenantId )) {
+      withTenant {
         // N.B. This is a groovy MAP, not a JSON document.
         TitleInstance.withNewTransaction {
           title_instance = TitleInstance.read(titleInstanceResolverService.resolve(content, true))
@@ -94,7 +94,7 @@ class TitleServiceSpec extends BaseSpec {
 
       // We are exercising the service directly, normally a transactional context will
       // be supplied by the HTTPRequest, but we fake it here to talk directly to the service
-      Tenants.withId(OkapiTenantResolver.getTenantSchemaName( tenantId )) {
+      withTenant {
         TitleInstance.withNewTransaction {
           title_instance = TitleInstance.read(titleInstanceResolverService.resolve(content, true))
           assert title_instance != null

--- a/service/src/integration-test/groovy/org/olf/StringTemplate/StringTemplateBulkSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/StringTemplate/StringTemplateBulkSpec.groovy
@@ -38,7 +38,7 @@ package org.olf.StringTemplate
 //      println "PKG DATA: ${package_data}"
 //      int result = 0
 //      final String tenantid = currentTenant.toLowerCase()
-//      Tenants.withId(OkapiTenantResolver.getTenantSchemaName( tenantid )) {
+//      withTenant {
 //        result = importService.importPackageUsingInternalSchema( package_data )
 //      }
 //      

--- a/service/src/integration-test/groovy/org/olf/TIRS/IdFirstTIRS/IdFirstTIRSSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/TIRS/IdFirstTIRS/IdFirstTIRSSpec.groovy
@@ -404,17 +404,8 @@ class IdFirstTIRSSpec extends TIRSSpec {
           identifier: newEissn,
           status: IdentifierOccurrence.lookupOrCreateStatus('approved'),
           resource: electronicTi2
-        ).save(failOnError: true, flush: true); // Flushing here because there's some weirdness in the TI save below
+        ).save(failOnError: true, flush: true); // Flushing here because transactions are normally per test method.
       }
-/*       withTenantNewTransaction {
-        electronicTi1.addToIdentifiers(eissnIO1);
-        electronicTi2.addToIdentifiers(eissnIO2);
-        printTI1.addToIdentifiers(pissnIO);
-
-        electronicTi1.save(failOnError: true);
-        electronicTi2.save(failOnError: true);
-        printTi1.save(failOnError: true);
-      } */
     then: 'All good'
       noExceptionThrown();
     when: 'We subsequently fetch the titleInstances'

--- a/service/src/integration-test/groovy/org/olf/TIRS/IdFirstTIRS/IdFirstTIRSSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/TIRS/IdFirstTIRS/IdFirstTIRSSpec.groovy
@@ -72,7 +72,7 @@ class IdFirstTIRSSpec extends TIRSSpec {
   @Requires({ instance.isIdTIRS() })
   void 'Test title creation' () {
     when: 'IdFirstTIRS is passed a title citation'
-      Tenants.withId(OkapiTenantResolver.getTenantSchemaName( tenantId )) {
+      withTenant {
         titleInstanceResolverService.resolve(brainOfTheFirm, true);
       }
     then: 'All good'
@@ -133,7 +133,7 @@ class IdFirstTIRSSpec extends TIRSSpec {
       List<TitleInstance> tis;
       TitleInstance electronicTi;
       String originalTiId;
-      Tenants.withId(OkapiTenantResolver.getTenantSchemaName( tenantId )) {
+      withTenant {
         tis = getFullTIsForWork(getWorkFromSourceId(workSourceId).id);
         electronicTi = tis.find(ti -> ti.subType.value == 'electronic');
         originalTiId = electronicTi.id;
@@ -146,7 +146,7 @@ class IdFirstTIRSSpec extends TIRSSpec {
       String resolvedTiId;
       TitleInstance resolvedTi;
 
-      Tenants.withId(OkapiTenantResolver.getTenantSchemaName( tenantId )) {
+      withTenant {
         resolvedTiId = titleInstanceResolverService.resolve(bindMapToCitationFromFile('match_on_identifiers.json', wsitirs_citation_path), true);
         resolvedTi = TitleInstance.get(resolvedTiId);
 
@@ -169,7 +169,7 @@ class IdFirstTIRSSpec extends TIRSSpec {
       String originalElectronicTiId;
       String originalPrintTiId;
 
-      Tenants.withId(OkapiTenantResolver.getTenantSchemaName( tenantId )) {
+      withTenant {
         tis = getFullTIsForWork(getWorkFromSourceId(workSourceId).id);
         electronicTi = tis.find(ti -> ti.subType.value == 'electronic');
         printTi = tis.find(ti -> ti.subType.value == 'print');
@@ -188,7 +188,7 @@ class IdFirstTIRSSpec extends TIRSSpec {
       Set<TitleInstance> resolvedSiblings;
       TitleInstance resolvedPrintSibling;
 
-      Tenants.withId(OkapiTenantResolver.getTenantSchemaName( tenantId )) {
+      withTenant {
         resolvedTiId = titleInstanceResolverService.resolve(bindMapToCitationFromFile('match_on_sibling.json', wsitirs_citation_path), true);
         resolvedTi = TitleInstance.get(resolvedTiId);
 
@@ -214,7 +214,7 @@ class IdFirstTIRSSpec extends TIRSSpec {
 
       Set<IdentifierOccurrence> originalIdentifiers;
 
-      Tenants.withId(OkapiTenantResolver.getTenantSchemaName( tenantId )) {
+      withTenant {
         tis = getFullTIsForWork(getWorkFromSourceId(workSourceId).id);
         electronicTi = tis.find(ti -> ti.subType.value == 'electronic');
         originalTiId = electronicTi.id;
@@ -235,7 +235,7 @@ class IdFirstTIRSSpec extends TIRSSpec {
       Set<IdentifierOccurrence> resolvedIdentifiers;
       Set<IdentifierOccurrence> resolvedApprovedIdentifiers;
 
-      Tenants.withId(OkapiTenantResolver.getTenantSchemaName( tenantId )) {
+      withTenant {
         resolvedTiId = titleInstanceResolverService.resolve(bindMapToCitationFromFile('match_on_fuzzy_title.json', wsitirs_citation_path), true);
         resolvedTi = TitleInstance.get(resolvedTiId);
 
@@ -254,7 +254,7 @@ class IdFirstTIRSSpec extends TIRSSpec {
   void 'IdFirstTIRS behaves as expected when we match multiple TIs' () {
     when: 'We set up secondary TI that IdFirst fallback will find'
       String eissn = "1234-5678-MM"
-      Tenants.withId(OkapiTenantResolver.getTenantSchemaName( tenantId )) {
+      withTenant {
         Identifier eissnId = Identifier.executeQuery("""
           SELECT iden FROM Identifier iden
           WHERE iden.value = :eissn
@@ -278,7 +278,7 @@ class IdFirstTIRSSpec extends TIRSSpec {
       noExceptionThrown()
     when: "We count IdentifierOccurrences for the eissn ${eissn}"
       Integer ioCount;
-      Tenants.withId(OkapiTenantResolver.getTenantSchemaName( tenantId )) {
+      withTenant {
         ioCount = IdentifierOccurrence.executeQuery("""
           SELECT COUNT(iden.id) FROM IdentifierOccurrence AS iden
           WHERE iden.identifier.value = :eissn
@@ -288,7 +288,7 @@ class IdFirstTIRSSpec extends TIRSSpec {
       assert ioCount == 2;
     when: 'We fetch the existing TIs and Siblings'
       List<String> existingTiIds;
-      Tenants.withId(OkapiTenantResolver.getTenantSchemaName( tenantId )) {
+      withTenant {
         existingTiIds = IdentifierOccurrence.executeQuery("""
           SELECT io.resource.id FROM IdentifierOccurrence io
           WHERE io.identifier.value = :eissn
@@ -299,7 +299,7 @@ class IdFirstTIRSSpec extends TIRSSpec {
     when: 'We resolve a title with non-matching sourceId and there are multiple matches -- throws expected exception'
       Long code
       String message
-      Tenants.withId(OkapiTenantResolver.getTenantSchemaName( tenantId )) {
+      withTenant {
         try {
           String tiId = titleInstanceResolverService.resolve(citationFromFile('match_multiple_tis.json'), true);
         } catch (TIRSException e) {

--- a/service/src/integration-test/groovy/org/olf/TIRS/TIRSSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/TIRS/TIRSSpec.groovy
@@ -59,7 +59,7 @@ abstract class TIRSSpec extends BaseSpec {
 
   @Ignore
   protected RemoteKB setUpDebugKb(String xmlPackagePath) {
-    Tenants.withId(OkapiTenantResolver.getTenantSchemaName( tenantId )) {
+    withTenant {
       RemoteKB.findByName('DEBUG') ?: (new RemoteKB(
         name:'DEBUG',
         type:'org.olf.kb.adapters.DebugGoKbAdapter',

--- a/service/src/integration-test/resources/packages/idFirstTIRS/citations/fix_equivalent_ids.json
+++ b/service/src/integration-test/resources/packages/idFirstTIRS/citations/fix_equivalent_ids.json
@@ -1,0 +1,11 @@
+{
+  "title":"fixEquivalentIds-test1",
+  "instanceMedium": "electronic",
+  "instanceMedia": "serial",
+  "instanceIdentifiers": [{
+    "namespace": "issn",
+    "value": "fei-123-456"
+  }],
+  "sourceIdentifierNamespace": "K-Int",
+  "sourceIdentifier": "fei-001"
+}

--- a/service/src/integration-test/resources/packages/idFirstTIRS/citations/fix_equivalent_ids_2.json
+++ b/service/src/integration-test/resources/packages/idFirstTIRS/citations/fix_equivalent_ids_2.json
@@ -1,0 +1,11 @@
+{
+  "title":"fixEquivalentIds-test3",
+  "instanceMedium": "electronic",
+  "instanceMedia": "serial",
+  "instanceIdentifiers": [{
+    "namespace": "issn",
+    "value": "fei-321-abc"
+  }],
+  "sourceIdentifierNamespace": "K-Int",
+  "sourceIdentifier": "fei-003"
+}

--- a/service/src/integration-test/resources/packages/idFirstTIRS/citations/fix_equivalent_ids_3.json
+++ b/service/src/integration-test/resources/packages/idFirstTIRS/citations/fix_equivalent_ids_3.json
@@ -1,0 +1,11 @@
+{
+  "title":"fixEquivalentIds-test3",
+  "instanceMedium": "electronic",
+  "instanceMedia": "serial",
+  "instanceIdentifiers": [{
+    "namespace": "doi",
+    "value": "testing-identifier-123"
+  }],
+  "sourceIdentifierNamespace": "K-Int",
+  "sourceIdentifier": "fei-003"
+}

--- a/service/src/integration-test/resources/packages/idFirstTIRS/ifitirs_pkg.json
+++ b/service/src/integration-test/resources/packages/idFirstTIRS/ifitirs_pkg.json
@@ -70,10 +70,44 @@
       }],
       "coverage": [],
       "embargo": null,
-      "url": "http://testpackage.com/journal/index.php?journalID=aah-008",
+      "url": "http://testpackage.com/journal/index.php?journalID=xxx-001",
       "platformName": "K-Int",
       "sourceIdentifierNamespace": "K-Int",
       "sourceIdentifier": "xxx-001"
+    },
+    {
+      "title": "fixEquivalentIds-test1",
+      "instanceMedium": "electronic",
+      "instanceMedia": "journal",
+      "instanceIdentifiers": [{
+        "namespace": "eissn",
+        "value": "fei-123-456"
+      }],
+      "siblingInstanceIdentifiers": [{
+        "namespace": "pissn",
+        "value": "fei-123-456"
+      }],
+      "coverage": [],
+      "embargo": null,
+      "url": "http://testpackage.com/journal/index.php?journalID=fei-001",
+      "platformName": "K-Int",
+      "sourceIdentifierNamespace": "K-Int",
+      "sourceIdentifier": "fei-001"
+    },
+    {
+      "title": "fixEquivalentIds-test2",
+      "instanceMedium": "electronic",
+      "instanceMedia": "journal",
+      "instanceIdentifiers": [{
+        "namespace": "eissn",
+        "value": "fei-abc-def"
+      }],
+      "coverage": [],
+      "embargo": null,
+      "url": "http://testpackage.com/journal/index.php?journalID=fei-002",
+      "platformName": "K-Int",
+      "sourceIdentifierNamespace": "K-Int",
+      "sourceIdentifier": "fei-002"
     }
   ]
 }

--- a/service/src/integration-test/resources/packages/idFirstTIRS/ifitirs_pkg.json
+++ b/service/src/integration-test/resources/packages/idFirstTIRS/ifitirs_pkg.json
@@ -108,6 +108,21 @@
       "platformName": "K-Int",
       "sourceIdentifierNamespace": "K-Int",
       "sourceIdentifier": "fei-002"
+    },
+    {
+      "title": "fixEquivalentIds-test3",
+      "instanceMedium": "electronic",
+      "instanceMedia": "journal",
+      "instanceIdentifiers": [{
+        "namespace": "issn",
+        "value": "fei-321-abc"
+      }],
+      "coverage": [],
+      "embargo": null,
+      "url": "http://testpackage.com/journal/index.php?journalID=fei-003",
+      "platformName": "K-Int",
+      "sourceIdentifierNamespace": "K-Int",
+      "sourceIdentifier": "fei-003"
     }
   ]
 }

--- a/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/BaseTIRS.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/BaseTIRS.groovy
@@ -60,7 +60,8 @@ abstract class BaseTIRS implements TitleInstanceResolverService {
   }
 
   /*
-   * Given an identifier in a citation { value:'1234-5678', namespace:'isbn' } lookup or create an identifier in the DB to represent that info
+   * Given an identifier in a citation { value:'1234-5678', namespace:'isbn' }
+   * lookup or create an identifier in the DB to represent that info.
    */
   protected String lookupOrCreateIdentifier(final String value, final String namespace) {
     String result = null;

--- a/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/BaseTIRS.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/BaseTIRS.groovy
@@ -58,7 +58,7 @@ abstract class BaseTIRS implements TitleInstanceResolverService {
   protected String lookupOrCreateIdentifier(final String value, final String namespace) {
     String result = null;
     try {
-      result = identifierService.lookupOrCreateIdentifier(value, namespace);
+      result = identifierService.lookupOrCreateIdentifier(value, namespace, true); // We need this to flush in TIRS logic
     } catch (IdentifierException ie) {
       // Any other exceptions should not be caught and rethrown -- leave them to be caught above as normal;
       if (ie.code == IdentifierException.MULTIPLE_IDENTIFIER_MATCHES) {

--- a/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/BaseTIRS.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/BaseTIRS.groovy
@@ -448,17 +448,15 @@ abstract class BaseTIRS implements TitleInstanceResolverService {
     }
   }
 
-  // Dedeuplicate a list of Ids
+  // Dedeuplicate a list of Ids by converting to HashSet and back
+  // This will LOSE order, but be O(n) instead of O(n^2) with "unique" etc.
   protected List<String> listDeduplictor(List<String> ids) {
-    // Need to deduplicate output -- Could probably be neater code than this
-    List<String> outputList = [];
-    ids.each { obj ->
-      if (!outputList.contains(obj)) {
-        outputList << obj
-      }
-    }
+    def uniqueIds = ids as HashSet<String>;
 
-    outputList
+    List<String> outputList = [];
+    outputList.addAll(uniqueIds);
+
+    return outputList
   }
 
   protected void ensureSourceIdentifierFields(final ContentItemSchema citation) {

--- a/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/BaseTIRS.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/BaseTIRS.groovy
@@ -60,7 +60,7 @@ abstract class BaseTIRS implements TitleInstanceResolverService {
     try {
       result = identifierService.lookupOrCreateIdentifier(value, namespace);
     } catch (IdentifierException ie) {
-      // Any other exceptions should not be caught and rethrown;
+      // Any other exceptions should not be caught and rethrown -- leave them to be caught above as normal;
       if (ie.code == IdentifierException.MULTIPLE_IDENTIFIER_MATCHES) {
         throw new TIRSException(
           ie.message,
@@ -68,7 +68,7 @@ abstract class BaseTIRS implements TitleInstanceResolverService {
         )
       }
 
-      throw new TIRSException(ie.message) // Otherwise rethrow as a generic TIRSException
+      throw ie // Otherwise rethrow as is
     }
 
     return result;

--- a/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/BaseTIRS.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/BaseTIRS.groovy
@@ -508,6 +508,8 @@ abstract class BaseTIRS implements TitleInstanceResolverService {
   // Direct match will find ALL title instances which match ANY of the instanceIdentifiers passed. Is extremely naive.
   // (Can be swapped to match only TIs with _all_ of the identifiers)
   // Allow for non-approved identifiers if we wish
+
+  // TODO -- we should make sure that if this ever ends up used in anger it gets integration test cases added
   public List<String> directMatch(
     final Iterable<IdentifierSchema> identifiers,
     String workId = null,

--- a/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/IdFirstTIRSImpl.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/IdFirstTIRSImpl.groovy
@@ -179,12 +179,11 @@ class IdFirstTIRSImpl extends BaseTIRS implements DataBinder {
   '''
 
   protected String getDirectMatchHQL(Collection<IdentifierSchema> identifiers, String workId = null, boolean approvedIdsOnly = true) {
-    String identifierHQL = buildIdentifierHQL(identifiers, approvedIdsOnly)
+    String identifierHQL = buildIdentifierHQL2(identifiers, approvedIdsOnly)
 
     // TODO Direct match (via identifierHQL) assumes single identfier I think... not sure this is right
     String outputHQL = """
       SELECT ti.id FROM TitleInstance as ti
-      JOIN ti.identifiers as io
       WHERE
         ${identifierHQL} AND
         ti.subType.value = :subtype
@@ -337,11 +336,10 @@ class IdFirstTIRSImpl extends BaseTIRS implements DataBinder {
       return []
     }
 
-    String siblingIdentifierHQL = buildIdentifierHQL(classOneIds);
+    String siblingIdentifierHQL = buildIdentifierHQL2(classOneIds, true, 'sibling');
     String siblingsHQL = """
       SELECT sibling.work.id FROM TitleInstance as sibling 
-        JOIN sibling.identifiers as io
-      WHERE 
+      WHERE
         ${siblingIdentifierHQL}
     """
 

--- a/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/IdFirstTIRSImpl.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/IdFirstTIRSImpl.groovy
@@ -138,6 +138,7 @@ class IdFirstTIRSImpl extends BaseTIRS implements DataBinder {
 
     result = createNewTitleInstanceWithoutIdentifiers(citation, workId)
     citation.instanceIdentifiers.each { id ->
+      // namespaceMapping is called in BaseTIRS lookupOrCreateIdentifier
       Identifier id_lookup = Identifier.get(lookupOrCreateIdentifier(id.value, id.namespace));
       def io_record = new IdentifierOccurrence(
         status: IdentifierOccurrence.lookupOrCreateStatus('approved'),

--- a/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/TitleFirstTIRSImpl.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/TitleFirstTIRSImpl.groovy
@@ -201,7 +201,7 @@ class TitleFirstTIRSImpl extends BaseTIRS {
           log.debug("No title match, create new title")
           ti = createNewTitleInstance(citation)
           if (ti != null && (citation.siblingInstanceIdentifiers?.size() ?: 0) > 0) {
-            // FIXME this is completely different logic to what we have elsewhere, where we create a new sibling for each identifier
+            // NOTE This is completely different logic to what we have elsewhere, where we create a new sibling for each identifier
             createPrintSibling(citation, ti.work.id)
           }
           break;

--- a/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/WorkSourceIdentifierTIRSImpl.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/WorkSourceIdentifierTIRSImpl.groovy
@@ -320,6 +320,7 @@ class WorkSourceIdentifierTIRSImpl extends IdFirstTIRSImpl implements DataBinder
 
       if (!io) {
         // Identifier from citation not on TI, add it
+        // namespaceMapping is called in BaseTIRS lookupOrCreateIdentifier
         Identifier id = Identifier.get(lookupOrCreateIdentifier(citation_id.value, citation_id.namespace))
         IdentifierOccurrence newIO = new IdentifierOccurrence([
           identifier: id,

--- a/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/WorkSourceIdentifierTIRSImpl.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/WorkSourceIdentifierTIRSImpl.groovy
@@ -313,6 +313,7 @@ class WorkSourceIdentifierTIRSImpl extends IdFirstTIRSImpl implements DataBinder
 
     // First ensure all identifiers from citation are on TI
     identifiers.each {IdentifierSchema citation_id ->
+      // CHECK identifiers so we can un-error an existing id if necessary
       IdentifierOccurrence io = ti.identifiers.find { IdentifierOccurrence ti_id ->
         ti_id.identifier.ns.value == namespaceMapping(citation_id.namespace) &&
         ti_id.identifier.value == citation_id.value
@@ -337,8 +338,8 @@ class WorkSourceIdentifierTIRSImpl extends IdFirstTIRSImpl implements DataBinder
       }
     }
 
-    // Next ensure ONLY identifiers from citation are on TI
-    ti.identifiers.each { IdentifierOccurrence io ->
+    // Next ensure ONLY identifiers from citation are on TI (We can check just the approved ones here)
+    ti.approvedIdentifierOccurrences.each { IdentifierOccurrence io ->
       IdentifierSchema ids = identifiers.find { citation_id ->
         io.identifier.ns.value == namespaceMapping(citation_id.namespace) &&
         io.identifier.value == citation_id.value

--- a/service/src/main/groovy/org/olf/kb/IdentifierException.groovy
+++ b/service/src/main/groovy/org/olf/kb/IdentifierException.groovy
@@ -4,6 +4,7 @@ package org.olf.kb;
 public class IdentifierException extends Exception {
   public static final Long GENERIC_ERROR = 0L;
   public static final Long MULTIPLE_IDENTIFIER_MATCHES = 1L;
+  public static final Long FIX_IDENTIFIER_ERROR = 2L;
 
 
   final Long code;

--- a/service/src/main/groovy/org/olf/kb/IdentifierException.groovy
+++ b/service/src/main/groovy/org/olf/kb/IdentifierException.groovy
@@ -1,0 +1,20 @@
+package org.olf.kb;
+
+// Special exception we can catch and do logic on -- used to coordinate between IdentifierService and TIRSs
+public class IdentifierException extends Exception {
+  public static final Long GENERIC_ERROR = 0L;
+  public static final Long MULTIPLE_IDENTIFIER_MATCHES = 1L;
+
+
+  final Long code;
+
+  public IdentifierException(String errorMessage, Long code) {
+    super(errorMessage);
+    this.code = code;
+  }
+
+  public IdentifierException(String errorMessage) {
+    super(errorMessage);
+    this.code = GENERIC_ERROR;
+  }
+}


### PR DESCRIPTION
- Performance tweak to deduplicateList method
- Fix for buildIdentifierHQL in cases where it is called with multiple identifiers (which atm we shouldn't hit anyway, but was logically flawed and could have caused us issues down the road)
- TODO IdentifierService method which can "fix" a multiple identifier exception in the case of issn/eissn/pissn or isbn/eisbn/pisbn