### PR TITLE
ERM-3299: Minimise supplementary term data populated as reference data

### DIFF
--- a/service/grails-app/services/org/olf/ErmHousekeepingService.groovy
+++ b/service/grails-app/services/org/olf/ErmHousekeepingService.groovy
@@ -84,35 +84,17 @@ public class ErmHousekeepingService {
           RefdataValue.lookupOrCreate('Yes/No/Other', 'No')
           RefdataValue.lookupOrCreate('Yes/No/Other', 'Other (see notes)')
 
-          RefdataValue.lookupOrCreate('AuthIdent', 'Other')
-          RefdataValue.lookupOrCreate('AuthIdent', 'Email Domain')
-          RefdataValue.lookupOrCreate('AuthIdent', 'ORCID')
-          RefdataValue.lookupOrCreate('AuthIdent', 'Over Institute')
-          RefdataValue.lookupOrCreate('AuthIdent', 'Over IP Range')
-          RefdataValue.lookupOrCreate('AuthIdent', 'Ringgold ID')
-          RefdataValue.lookupOrCreate('AuthIdent', 'ROR ID')
-
           // Read the categories.
           final String yesno = RefdataCategory.findByDesc('Yes/No/Other').id
-          final String authident = RefdataCategory.findByDesc('AuthIdent').id
 
           [
-            [
-              "ctx" : "OpenAccess",
-              "name" : "AuthorIdentification",
-              "category" : authident,
-              "type" : "Refdata",
-              "label" : "Author Identification",
-              "description" : "Author Identification",
-              "primary": true
-            ],
             [
               "ctx" : "OpenAccess",
               "name" : "SupportPublishing",
               "type" : "Text",
               "label" : "Does this agreement support publishing",
               "description" : "Does this agreement support publishing",
-              "primary": true
+              "primary": false
             ]
           ].each { Map definition ->
             


### PR DESCRIPTION
Removed the authoridentification supplementary property from the mod-agreements ErmHousekeepingService

Removed the AuthIdent reference data category and all related values from the mod-agreements ErmHousekeepingService

Updated the SupportPublishing supplementary property to be primary = false

[ERM-3299](https://folio-org.atlassian.net/browse/ERM-3299)