### PR TITLE
chore: Clear session after adding titles and packages in order to flush cache

### DIFF
--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -213,8 +213,8 @@ class PackageIngestService implements DataBinder {
 				
 						return result
 					}
+          newSess.clear();
 				}
-        newSess.clear();
 			}
 		}
   }


### PR DESCRIPTION
In long running transactions by default hibernate objects are left in a cache even after commit. This will cause memory to balloon, especially when ingesting. This patch clears the cache eagerly to maintain memory at lower levels.