### PR TITLE
chore: Tweaked processing log message

### DIFF
--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -177,7 +177,7 @@ class PackageIngestService implements DataBinder {
 								log.debug ("(Package in progress) processed ${result.titleCount} titles, average per title: ${result.averageTimePerTitle}s")
 							} */
 						}
-						long finishedTime = (System.currentTimeMillis()-result.startTime)/1000
+						long finishedTime = (System.currentTimeMillis()-result.startTime) // Don't divide by 1000 here, instead leave in ms for greater accuracy
 				
 						// This removed logic is WRONG under pushKB because it's chunked -- ensure pushKB does not call full upsertPackage method
 						// At the end - Any PCIs that are currently live (Don't have a removedTimestamp) but whos lastSeenTimestamp is < result.updateTime
@@ -219,7 +219,7 @@ class PackageIngestService implements DataBinder {
     // Need to pause long enough so that the timestamps are different
     TimeUnit.MILLISECONDS.sleep(1)
     if (result.titleCount > 0) {
-      log.debug ("Processed ${result.titleCount} titles in ${finishedTime} seconds (${finishedTime/result.titleCount}s average)")
+      log.debug ("Processed ${result.titleCount} titles in ${finishedTime/1000} seconds (${(finishedTime/result.titleCount)/1000}s average)")
       log.info("Package titles summary::Processed/${result.titleCount}, Added/${result.newTitles}, Updated/${result.updatedTitles}, Removed/${result.removedTitles}, AccessStart/${result.updatedAccessStart}, AccessEnd/${result.updatedAccessEnd}")
 
       // Log the counts too.


### PR DESCRIPTION
Tiny tweak to processing message, saving calculation to be done in ms at the end for greater accuracy around per-title averages, allowing for a better picture of performance gains/hits when changes are made