### PR TITLE
fix: ERM-3308 fix: Coverage not propogated to TIs

### DIFF
--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -490,12 +490,20 @@ class PackageIngestService implements DataBinder {
       pti = new PlatformTitleInstance(titleInstance:title,
         platform:platform,
         url:pc.url,
-      ).save(failOnError: true)
+      );
+
+      // Ensure coverages don't change here... I _think_ this is only used during ingest where PCI coverage sweep will get triggered eventually
+      pti.doNotCalculateCoverage = true
+      pti.save(failOnError: true)
     } else if (trustedSourceTI) {
       // Update any PTI fields directly
       if (pti.url != pc.url) {
         pti.url = pc.url
       }
+
+      // Ensure coverages don't change here... I _think_ this is only used during ingest where PCI coverage sweep will get triggered eventually
+      pti.doNotCalculateCoverage = true
+
       pti.save(flush: true, failOnError: true)
     }
 
@@ -616,7 +624,7 @@ class PackageIngestService implements DataBinder {
         // We define coverage to be a list in the exchange format, but sometimes it comes just as a JSON map. Convert that
         // to the list of maps that coverageService.extend expects
         Iterable<CoverageStatementSchema> cov = pc.coverage instanceof Iterable ? pc.coverage : [ pc.coverage ]
-        // Ensure this doesn't trigger the calculateCoverage, that will happen after in the pci.save
+        // Ensure this doesn't trigger the calculateCoverage, that will happen on PCI save
         coverageService.setCoverageFromSchema (pci, cov, false)
       }
 


### PR DESCRIPTION
Ensured that calculateCoverage changes get _properly_ propogated through the heirachy. Previously changes would be one transaction behind because the flush hadn't taken hold yet. The reliance on flushes here is not ideal, but at least this works