### PR TITLE
ERM-3308: Coverage tweaks

### DIFF
--- a/service/grails-app/domain/org/olf/kb/CoverageStatement.groovy
+++ b/service/grails-app/domain/org/olf/kb/CoverageStatement.groovy
@@ -58,4 +58,9 @@ public class CoverageStatement extends AbstractCoverageStatement implements Vali
             endVolume column:'cs_end_volume'
              endIssue column:'cs_end_issue'
   }
+
+  // TODO is this a good enough toString to be official rather than "toGoKBString"?
+  String toString() {
+    "v${startVolume ?: '*'}/i${startIssue ?: '*'}/${startDate ?: '*'} - v${endVolume ?: '*'}/i${endIssue ?: '*'}/${endDate ?: '*'}"
+  }
 }

--- a/service/grails-app/services/org/olf/CoverageService.groovy
+++ b/service/grails-app/services/org/olf/CoverageService.groovy
@@ -141,7 +141,8 @@ public class CoverageService {
     final Iterable<CoverageStatementSchema> coverage_statements,
     final boolean calculateCoverageAtEnd = true
   ) {
-      //log.debug("CoverageService::setCoverageFromSchema(${resource}, ${coverage_statements}, ${calculateCoverageAtEnd})")
+    // resource is null for logging unless a gorm operation is applied to it... something something proxying something :p
+    //log.debug("CoverageService::setCoverageFromSchema(${resource}, ${coverage_statements}, ${calculateCoverageAtEnd})")
 
 //    ErmResource.withTransaction {
 
@@ -197,11 +198,12 @@ public class CoverageService {
         }
       } catch (ValidationException e) {
         // Don't bother erroring this to the user, the above validation errors will log through UtilityService
-        log.debug("Coverage changes to Resource ${resource.id} not saved")
+        log.debug("Coverage changes to resource ${resource} not saved. \n${e.message}")
+        //e.printStackTrace() // Can turn off except for dev
 
         // In this case we must RESET the coverage 
         // This shouldn't need to be a log error, as the validation error above comes from somewhere which ALREADY logs as error.
-        resource.coverage = [] // Ensure set if not existing initially, or cleared ready for reverting
+        resource.coverage?.clear();
 
         statements.each {
           resource.addToCoverage( it )

--- a/service/grails-app/services/org/olf/CoverageService.groovy
+++ b/service/grails-app/services/org/olf/CoverageService.groovy
@@ -192,10 +192,13 @@ public class CoverageService {
 
             // Throwing a ValildationException here we "reset" if even one coverageStatement is wrong.
             // Without this we simply ignore the incorrect statement and try to continue...
-            throw new ValidationException('Coverage statement is incorrect')
+            throw new ValidationException('Coverage statement is incorrect', cs.errors)
           }
         }
       } catch (ValidationException e) {
+        // Don't bother erroring this to the user, the above validation errors will log through UtilityService
+        log.debug("Coverage changes to Resource ${resource.id} not saved")
+
         // In this case we must RESET the coverage 
         // This shouldn't need to be a log error, as the validation error above comes from somewhere which ALREADY logs as error.
         resource.coverage = [] // Ensure set if not existing initially, or cleared ready for reverting

--- a/service/grails-app/services/org/olf/UtilityService.groovy
+++ b/service/grails-app/services/org/olf/UtilityService.groovy
@@ -29,15 +29,15 @@ class UtilityService {
   }
 
   // Small utility method to log out any errors
-  private void logErrors(Errors errors) {
+  private void logErrors(Errors errors, String extraContext = '') {
     errors.allErrors.each { ObjectError error ->
-      log.error "${ messageSource.getMessage(error, LocaleContextHolder.locale) }"
+      log.error "${ messageSource.getMessage(error, LocaleContextHolder.locale) }. ${extraContext}"
     }
   }
 
   // Small utility method to systematically check binding and log out any errors
   // Provide separate checkValidBinding for Validateable vs GormEntity objects
-  public boolean checkValidBinding(GormEntity obj) {
+  public boolean checkValidBinding(GormEntity obj, String extraContext = '') {
     boolean validBinding = false;
     // Check for binding errors.
     if (!obj.errors.hasErrors()) {
@@ -48,11 +48,11 @@ class UtilityService {
         validBinding = true;
       } else {
         // Log the errors.
-        logErrors(obj.errors)
+        logErrors(obj.errors, extraContext)
       }
     } else {
       // Log the errors.
-      logErrors(obj.errors)
+      logErrors(obj.errors, extraContext)
     }
 
     validBinding
@@ -60,7 +60,7 @@ class UtilityService {
 
   // Small utility method to systematically check binding and log out any errors
   // Provide separate checkValidBinding for Validateable vs GormEntity objects
-  public boolean checkValidBinding(Validateable obj) {
+  public boolean checkValidBinding(Validateable obj, String extraContext = '') {
     boolean validBinding = false;
     // Check for binding errors.
     if (!obj.errors.hasErrors()) {
@@ -71,11 +71,11 @@ class UtilityService {
         validBinding = true;
       } else {
         // Log the errors.
-        logErrors(obj.errors)
+        logErrors(obj.errors, extraContext)
       }
     } else {
       // Log the errors.
-      logErrors(obj.errors)
+      logErrors(obj.errors, extraContext)
     }
 
     validBinding

--- a/service/src/main/groovy/org/olf/dataimport/erm/CoverageStatement.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/erm/CoverageStatement.groovy
@@ -30,4 +30,9 @@ class CoverageStatement extends AbstractCoverageStatement implements CoverageSta
     endVolume(nullable:true, blank:false)
     endIssue(nullable:true, blank:false)
   }
+
+  // Reflected by internal CoverageStatement toString...
+  String toString() {
+    "v${startVolume ?: '*'}/i${startIssue ?: '*'}/${startDate ?: '*'} - v${endVolume ?: '*'}/i${endIssue ?: '*'}/${endDate ?: '*'}"
+  }
 }

--- a/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
+++ b/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
@@ -492,19 +492,24 @@ public class GOKbOAIAdapter extends WebSourceAdapter implements KBCacheUpdater, 
 
           tipp_coverage.addAll(tipp_entry.coverage.collect { cov ->
             // Our domain model does not allow null startDate or endDate
-            String start_date_string = cov.@startDate?.toString()
-            String end_date_string = cov.@endDate?.toString()
+            String start_date_string = cov.@startDate?.toString()?.trim()
+            String end_date_string = cov.@endDate?.toString()?.trim()
 
-            return [
-              "startVolume": cov.@startVolume?.toString(),
-              "startIssue": cov.@startIssue?.toString(),
-              "startDate": start_date_string?.length() > 0 ? start_date_string : null,
-              "endVolume": cov.@endVolume?.toString(),
-              "endIssue": cov.@endIssue?.toString(),
-              "endDate": end_date_string?.length() > 0 ? end_date_string : null
-            ]
-          });
+            if (start_date_string && end_date_string) {
+              return [
+                "startVolume": cov.@startVolume?.toString(),
+                "startIssue": cov.@startIssue?.toString(),
+                "startDate": start_date_string?.length() > 0 ? start_date_string : null,
+                "endVolume": cov.@endVolume?.toString(),
+                "endIssue": cov.@endIssue?.toString(),
+                "endDate": end_date_string?.length() > 0 ? end_date_string : null
+              ]
+            } else {
+              // Rejected coverage statement which would fail anyway.
+            }
+          }.findAll { it != null })
 
+          // TODO if there are multiple coverages, these will get concatenated naively
           def tipp_coverage_depth = tipp_entry.coverage.@coverageDepth?.toString()
           def tipp_coverage_note = tipp_entry.coverage.@coverageNote?.toString()
 

--- a/service/src/main/okapi/tenant/sample_data/_data.groovy
+++ b/service/src/main/okapi/tenant/sample_data/_data.groovy
@@ -12,7 +12,8 @@ import org.olf.kb.RemoteKB
     rectype: RemoteKB.RECTYPE_PACKAGE,
     active:Boolean.TRUE,
     supportsHarvesting:true,
-    activationEnabled:false
+    activationEnabled:false,
+    //cursor: "2022-08-09T19:34:42Z"
 ).save(failOnError:true)) */
 
 RemoteKB.findByName('GOKb') ?: (new RemoteKB(


### PR DESCRIPTION
Fixes issue with coverage calculation when resource coverage already exists
Major tweaks to logging... only log coverage issues 1 time, change over to including the failing coverage and the revert set so the users can point to the resource where coverage may not be "up to date" with gokb


refs ERM-3308