### PR TITLE
chore: Turn off two logging messages

### DIFF
--- a/service/grails-app/services/org/olf/TitleIngestService.groovy
+++ b/service/grails-app/services/org/olf/TitleIngestService.groovy
@@ -64,7 +64,8 @@ class TitleIngestService implements DataBinder {
       trustedSourceTI = false
     }
     else {
-      log.debug("Not trusted source ti");
+      // Not really useful except for debugging
+      //log.debug("Not trusted source ti");
     }
 
     result.updateTime = System.currentTimeMillis()

--- a/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/IdFirstTIRSImpl.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/titleInstanceResolvers/IdFirstTIRSImpl.groovy
@@ -122,7 +122,8 @@ class IdFirstTIRSImpl extends BaseTIRS implements DataBinder {
 
         switch ( candidate_list.size() ) {
           case 0:
-            log.debug("Create sibling print instance for citation ${sibling_citation}")
+            // We don't really need to log out that we're creating a sibling print instance, as it almost always happens 1 time per ingest title
+            //log.debug("Create sibling print instance for citation ${sibling_citation}")
             createNewTitleInstance(sibling_citation, workId)
             break
           case 1:


### PR DESCRIPTION
Turn off two of the loudest logging messages that don't really give us any developer information