### PR TITLE
fix: Migrations pre-breaking GIN index insertion

### DIFF
--- a/service/grails-app/migrations/correct-gin-indices-pre-poppy.groovy
+++ b/service/grails-app/migrations/correct-gin-indices-pre-poppy.groovy
@@ -1,0 +1,88 @@
+databaseChangeLog = {
+  /* GIN Indexes have been added in update-mod-agreements-6-0.groovy
+   * These can cause issues when the underlying data passes a certain limit
+   * due to trigram operator not being used and the postgres token size growing
+   *
+   * It is a little unorthodox, however these index creations are conditional on
+   * "CREATE IF NOT EXISTS". We will make use of that to insert indices on those
+   * fields _before_ they are set up by upgrading/new implementors. For any tenants
+   * who already managed to upgrade, these new changesets will be ignored, but it
+   * it _recommended_ that an operational task be undertaken to bring those schemas
+   * in line with the indices in place on new instances of mod-agreements
+   */
+
+  changeSet(author: "EFreestone (manual)", id: "2024-09-06-ERM-3321-poppy-1") {
+		preConditions (onFail: 'MARK_RAN', onError: 'WARN') {
+			not {
+				indexExists(tableName: 'alternate_resource_name', columnNames: 'arn_name')
+			}
+		}
+		// Gin indexes need to be done via scripting.
+		grailsChange {
+			change {
+				def cmd = "CREATE INDEX arn_name_idx ON ${database.defaultSchemaName}.alternate_resource_name USING gin (arn_name gin_trgm_ops);".toString()
+				sql.execute(cmd);
+			}
+		}
+  }
+
+  changeSet(author: "EFreestone (manual)", id: "2024-09-06-ERM-3321-poppy-2") {
+		preConditions (onFail: 'MARK_RAN', onError: 'WARN') {
+			not {
+				indexExists(tableName: 'erm_resource', columnNames: 'res_description')
+			}
+		}
+		// Gin indexes need to be done via scripting.
+		grailsChange {
+			change {
+				def cmd = "CREATE INDEX erm_resource_res_description_idx ON ${database.defaultSchemaName}.erm_resource USING gin (res_description gin_trgm_ops);".toString()
+				sql.execute(cmd);
+			}
+		}
+  }
+
+  changeSet(author: "EFreestone (manual)", id: "2024-09-06-ERM-3321-poppy-3") {
+		preConditions (onFail: 'MARK_RAN', onError: 'WARN') {
+			not {
+				indexExists(tableName: 'identifier', columnNames: 'id_value')
+			}
+		}
+		// Gin indexes need to be done via scripting.
+		grailsChange {
+			change {
+				def cmd = "CREATE INDEX identifier_id_value_idx ON ${database.defaultSchemaName}.identifier USING gin (id_value gin_trgm_ops);".toString()
+				sql.execute(cmd);
+			}
+		}
+  }
+
+  changeSet(author: "EFreestone (manual)", id: "2024-09-06-ERM-3321-poppy-4") {
+		preConditions (onFail: 'MARK_RAN', onError: 'WARN') {
+			not {
+				indexExists(tableName: 'identifier_namespace', columnNames: 'idns_value')
+			}
+		}
+		// Gin indexes need to be done via scripting.
+		grailsChange {
+			change {
+				def cmd = "CREATE INDEX identifier_namespace_value_idx ON ${database.defaultSchemaName}.identifier_namespace USING gin (idns_value gin_trgm_ops);".toString()
+				sql.execute(cmd);
+			}
+		}
+  }
+
+  changeSet(author: "EFreestone (manual)", id: "2024-09-06-ERM-3321-poppy-5") {
+		preConditions (onFail: 'MARK_RAN', onError: 'WARN') {
+			not {
+				indexExists(tableName: 'refdata_category', columnNames: 'rdc_description')
+			}
+		}
+		// Gin indexes need to be done via scripting.
+		grailsChange {
+			change {
+				def cmd = "CREATE INDEX refdata_category_rdc_description_idx ON ${database.defaultSchemaName}.refdata_category USING gin (rdc_description gin_trgm_ops);".toString()
+				sql.execute(cmd);
+			}
+		}
+  }
+}

--- a/service/grails-app/migrations/correct-gin-indices-pre-quesnalia.groovy
+++ b/service/grails-app/migrations/correct-gin-indices-pre-quesnalia.groovy
@@ -1,0 +1,81 @@
+databaseChangeLog = {
+  /*
+   * See comment in correct-gin-indices-pre-poppy.groovy. Same applies here to
+   * pre-empt GIN indices set up in quesnalia upgrade file(s)
+   */
+
+  changeSet(author: "EFreestone (manual)", id: "2024-09-06-ERM-3321-quesnalia-1") {
+		preConditions (onFail: 'MARK_RAN', onError: 'WARN') {
+			not {
+				indexExists(tableName: 'entitlement', columnNames: 'ent_description')
+			}
+		}
+		// Gin indexes need to be done via scripting.
+		grailsChange {
+			change {
+				def cmd = "CREATE INDEX entitlement_description_idx ON ${database.defaultSchemaName}.entitlement USING gin (ent_description gin_trgm_ops);".toString()
+				sql.execute(cmd);
+			}
+		}
+  }
+
+  changeSet(author: "EFreestone (manual)", id: "2024-09-06-ERM-3321-quesnalia-2") {
+    preConditions (onFail: 'MARK_RAN', onError: 'WARN') {
+			not {
+				indexExists(tableName: 'entitlement', columnNames: 'ent_note')
+			}
+		}
+		// Gin indexes need to be done via scripting.
+		grailsChange {
+			change {
+				def cmd = "CREATE INDEX entitlement_note_idx ON ${database.defaultSchemaName}.entitlement USING gin (ent_note gin_trgm_ops);".toString()
+				sql.execute(cmd);
+			}
+		}
+  }
+  
+  changeSet(author: "EFreestone (manual)", id: "2024-09-06-ERM-3321-quesnalia-3") {
+		preConditions (onFail: 'MARK_RAN', onError: 'WARN') {
+			not {
+				indexExists(tableName: 'entitlement', columnNames: 'ent_reference')
+			}
+		}
+		// Gin indexes need to be done via scripting.
+		grailsChange {
+			change {
+				def cmd = "CREATE INDEX entitlement_reference_idx ON ${database.defaultSchemaName}.entitlement USING gin (ent_reference gin_trgm_ops);".toString()
+				sql.execute(cmd);
+			}
+		}
+  }
+
+  changeSet(author: "EFreestone (manual)", id: "2024-09-06-ERM-3321-quesnalia-4") {
+		preConditions (onFail: 'MARK_RAN', onError: 'WARN') {
+			not {
+				indexExists(tableName: 'platform', columnNames: 'pt_name')
+			}
+		}
+		// Gin indexes need to be done via scripting.
+		grailsChange {
+			change {
+				def cmd = "CREATE INDEX platform_name_idx ON ${database.defaultSchemaName}.platform USING gin (pt_name gin_trgm_ops);".toString()
+				sql.execute(cmd);
+			}
+		}
+  }
+
+  changeSet(author: "EFreestone (manual)", id: "2024-09-06-ERM-3321-quesnalia-5") {
+		preConditions (onFail: 'MARK_RAN', onError: 'WARN') {
+			not {
+				indexExists(tableName: 'subscription_agreement', columnNames: 'sa_description')
+			}
+		}
+		// Gin indexes need to be done via scripting.
+		grailsChange {
+			change {
+				def cmd = "CREATE INDEX subscription_agreement_description_idx ON ${database.defaultSchemaName}.subscription_agreement USING gin (sa_description gin_trgm_ops);".toString()
+				sql.execute(cmd);
+			}
+		}
+  }
+}

--- a/service/grails-app/migrations/module-tenant-changelog.groovy
+++ b/service/grails-app/migrations/module-tenant-changelog.groovy
@@ -28,7 +28,9 @@ databaseChangeLog = {
   include file: 'update-mod-agreements-5-3.groovy'
   include file: 'wtk/hidden-appsetting.feat.groovy'
   include file: 'update-mod-agreements-5-5.groovy'
+  include file: 'correct-gin-indices-pre-poppy.groovy'
   include file: 'update-mod-agreements-6-0.groovy'
+  include file: 'correct-gin-indices-pre-quesnalia.groovy'
   include file: 'add-quesnalia-indices-and-fk-constraints.groovy'
   include file: 'update-mod-agreements-6-1.groovy'
 }


### PR DESCRIPTION
Inserted migration files prior to `update-mod-agreements-6-0.groovy` and `add-quesnalia-indices-and-fk-constraints.groovy` files. These contain index definitions set up _before_ the non-trigramised (not sure if that's a word) versions in those files. This _should_ allow institutions who have already run these migrations to continue to work with the indices in place (Although we heavily recommend an operational task to bring those in line with the "tip of master" code, while allowing those institutions who are currently prevented from upgrading to do so as normal.

This is a slight misuse of migrations to accommodate this unfortunate gap between institutions who have already upgraded and those who have not.

NOTE: This does _not_ fix the issue where column `sa_name` on `subscription_agreement` table continues to not have a GIN index thanks to this column already having an index on that column from uniqueness constraint.

ERM-3321