### PR TITLE
ERM-3425: Missing interface dependencies in module descriptor in mod-agreements

### DIFF
--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -1041,6 +1041,12 @@
       ]
     }
   ],
+  "optional": [
+    {
+      "id": "organizations.organizations",
+      "version": "1.0"
+    }
+  ],
   "permissionSets": [
     {
       "permissionName": "erm.agreements.collection.get",


### PR DESCRIPTION
build: Add optional okapi dependencies to ModuleDescriptor

ERM-3425