### PR TITLE
fix: /erm/entitlements API returns invalid JSON data

### DIFF
--- a/service/grails-app/views/usageDataProvider/_usageDataProvider.gson
+++ b/service/grails-app/views/usageDataProvider/_usageDataProvider.gson
@@ -7,7 +7,7 @@ inherits template: "/remoteOkapiLink/remoteOkapiLink"
 
 json {
   if (usageDataProvider.usageDataProviderNote){
-    'usageDataProviderNote' g.render( usageDataProvider.usageDataProviderNote )
+    'usageDataProviderNote' usageDataProvider.usageDataProviderNote
   }
 
   if (params.controller == 'usageDataProvider') {

--- a/service/grails-app/views/usageDataProvider/_usageDataProvider.gson
+++ b/service/grails-app/views/usageDataProvider/_usageDataProvider.gson
@@ -5,10 +5,16 @@ import org.olf.erm.UsageDataProvider
 
 inherits template: "/remoteOkapiLink/remoteOkapiLink"
 
-def should_expand = ['usageDataProviderNote']
+json {
+  if (usageDataProvider.usageDataProviderNote){
+    'usageDataProviderNote' g.render( usageDataProvider.usageDataProviderNote )
+  }
 
-if (params.controller == 'usageDataProvider' ) {
-  should_expand << 'owner'
+  if (params.controller == 'usageDataProvider') {
+    'owner' g.render( usageDataProvider.owner )
+  } else {
+    'owner' {
+      'id' usageDataProvider.owner.id
+    }
+  }
 }
-
-json g.render(usageDataProvider, ['excludes': ['id', 'version', 'remoteId'], 'expand':should_expand])


### PR DESCRIPTION
Originally the erm/entitlements endpoint would return invalid JSON on an agreement with > 2 agreement lines and a usageDataProvider, due to an inherent bug within the grails-views plugin, the usageDataProvider view gson is now more explicitly typed to prevent this

ERM-3464