### PR TITLE
ERM-3567: Implement boolean “synchronise” property for packages: mod-agreements

### DIFF
--- a/service/grails-app/controllers/org/olf/PackageController.groovy
+++ b/service/grails-app/controllers/org/olf/PackageController.groovy
@@ -30,7 +30,7 @@ class PackageController extends OkapiTenantAwareController<Pkg> {
     super(Pkg)
   }
 
-  // FIXME we need to protect syncContentsFromSource on PUT.
+  // We need to protect syncContentsFromSource on PUT.
   //  We don't want this to be edited directly, instead it'll go via an action.
   @Override
   def update() {

--- a/service/grails-app/controllers/org/olf/PackageController.groovy
+++ b/service/grails-app/controllers/org/olf/PackageController.groovy
@@ -30,6 +30,25 @@ class PackageController extends OkapiTenantAwareController<Pkg> {
     super(Pkg)
   }
 
+  // FIXME we need to protect syncContentsFromSource on PUT.
+  //  We don't want this to be edited directly, instead it'll go via an action.
+  @Override
+  def update() {
+    Pkg instance = queryForResource(params.id);
+    Object object_to_bind = getObjectToBind();
+
+    // Check if Package has syncContentsFromSource set. If so,
+    // and we attempt to CHANGE it, refuse
+    if (
+        object_to_bind.syncContentsFromSource != null &&
+        instance.syncContentsFromSource != object_to_bind.syncContentsFromSource
+    ) {
+      response.sendError(422, "Directly editing syncContentsFromSource is not allowed");
+    } else {
+      super.update();
+    }
+  }
+
   def 'import' () {
     final bindObj = this.getObjectToBind()
     log.debug("Importing package: ${bindObj}")

--- a/service/grails-app/domain/org/olf/kb/Pkg.groovy
+++ b/service/grails-app/domain/org/olf/kb/Pkg.groovy
@@ -15,16 +15,23 @@ import grails.gorm.MultiTenant
  */
 public class Pkg extends ErmResource implements MultiTenant<Pkg> {
   String source
-  String reference  // Reference contains the KBs authoritative ID for this package - Reference should be unique within KB
-  Platform nominalPlatform
-  Org vendor
   Date sourceDataCreated
   Date sourceDataUpdated
   Integer sourceTitleCount
+
+  // A boolean to track whether we are choosing to sync the contents from the source or not
+  boolean syncContentsFromSource = false
+
+  String reference  // Reference contains the KBs authoritative ID for this package - Reference should be unique within KB
+
+  Platform nominalPlatform
+  Org vendor
+
   @Defaults(['Current', 'Retired', 'Expected', 'Deleted'])
   RefdataValue lifecycleStatus
   @Defaults(['Global'])
   RefdataValue availabilityScope
+
   Set<PackageDescriptionUrl> packageDescriptionUrls
   Set<ContentType> contentTypes
   Set<AvailabilityConstraint> availabilityConstraints
@@ -51,6 +58,7 @@ public class Pkg extends ErmResource implements MultiTenant<Pkg> {
   static mapping = {
                         table 'package'
                        source column:'pkg_source'
+       syncContentsFromSource column:'pkg_sync_contents_from_source'
                     reference column:'pkg_reference'
               nominalPlatform column:'pkg_nominal_platform_fk'
                        vendor column:'pkg_vendor_fk'
@@ -65,16 +73,17 @@ public class Pkg extends ErmResource implements MultiTenant<Pkg> {
   }
 
   static constraints = {
-               name(nullable:false, blank:false)
-             source(nullable:false, blank:false)
-          reference(nullable:false, blank:false)
-    nominalPlatform(nullable:true, blank:false)
-   sourceTitleCount(nullable:true, blank:false)
-             vendor(nullable:true, blank:false)
-  sourceDataCreated(nullable:true, blank:false)
-  sourceDataUpdated(nullable:true, blank:false)
-    lifecycleStatus(nullable:true, blank:false)
-  availabilityScope(nullable:true, blank:false)
+                         name(nullable:false, blank:false)
+                       source(nullable:false, blank:false)
+       syncContentsFromSource(nullable:true, blank:false) // Allow this to be null for now... will treat `null` as `false`)
+                    reference(nullable:false, blank:false)
+              nominalPlatform(nullable:true, blank:false)
+             sourceTitleCount(nullable:true, blank:false)
+                       vendor(nullable:true, blank:false)
+            sourceDataCreated(nullable:true, blank:false)
+            sourceDataUpdated(nullable:true, blank:false)
+              lifecycleStatus(nullable:true, blank:false)
+            availabilityScope(nullable:true, blank:false)
   }
 
   /*

--- a/service/grails-app/domain/org/olf/kb/Pkg.groovy
+++ b/service/grails-app/domain/org/olf/kb/Pkg.groovy
@@ -20,7 +20,7 @@ public class Pkg extends ErmResource implements MultiTenant<Pkg> {
   Integer sourceTitleCount
 
   // A boolean to track whether we are choosing to sync the contents from the source or not
-  boolean syncContentsFromSource = false
+  Boolean syncContentsFromSource = false
 
   String reference  // Reference contains the KBs authoritative ID for this package - Reference should be unique within KB
 

--- a/service/grails-app/migrations/module-tenant-changelog.groovy
+++ b/service/grails-app/migrations/module-tenant-changelog.groovy
@@ -34,4 +34,5 @@ databaseChangeLog = {
   include file: 'add-quesnalia-indices-and-fk-constraints.groovy'
   include file: 'update-mod-agreements-6-1.groovy'
   include file: 'update-mod-agreements-7-1.groovy'
+  include file: 'update-mod-agreements-7-2.groovy'
 }

--- a/service/grails-app/migrations/update-mod-agreements-7-2.groovy
+++ b/service/grails-app/migrations/update-mod-agreements-7-2.groovy
@@ -1,0 +1,7 @@
+databaseChangeLog = {
+  changeSet(author: "efreestone (manual)", id: "20250204-1444-001") {
+    addColumn(tableName: "package") {
+      column (name: "pkg_sync_contents_from_source", type: "BOOLEAN")
+    }
+  }
+}

--- a/service/grails-app/services/org/olf/ImportService.groovy
+++ b/service/grails-app/services/org/olf/ImportService.groovy
@@ -231,7 +231,8 @@ class ImportService implements DataBinder {
       packageSource: packageSource,
       packageSlug: packageReference,
       packageProvider: pkgPrv,
-      trustedSourceTI: trustedSourceTI
+      trustedSourceTI: trustedSourceTI,
+      syncContentsFromSource: true // This is defaulted right now, for more control the JSON import should be used
     )
 
     String[] record = file.readNext()
@@ -318,8 +319,7 @@ class ImportService implements DataBinder {
           monographEdition: getFieldFromLine(currentRecord, acceptedFields, 'monographEdition'),
           firstEditor: getFieldFromLine(currentRecord, acceptedFields, 'firstEditor'),
           sourceIdentifier: getFieldFromLine(currentRecord, acceptedFields, 'sourceIdentifier') ?: getFieldFromLine(currentRecord, acceptedFields, 'titleId'),
-          sourceIdentifierNamespace: getFieldFromLine(currentRecord, acceptedFields, 'sourceIdentifierNamespace') ?: packageSource,
-          syncContentsFromSource: true // This is defaulted right now, for more control the JSON import should be used
+          sourceIdentifierNamespace: getFieldFromLine(currentRecord, acceptedFields, 'sourceIdentifierNamespace') ?: packageSource
         )
         MDC.put('title', StringUtils.truncate(pkgLine.title))
 

--- a/service/grails-app/services/org/olf/ImportService.groovy
+++ b/service/grails-app/services/org/olf/ImportService.groovy
@@ -318,7 +318,7 @@ class ImportService implements DataBinder {
           monographEdition: getFieldFromLine(currentRecord, acceptedFields, 'monographEdition'),
           firstEditor: getFieldFromLine(currentRecord, acceptedFields, 'firstEditor'),
           sourceIdentifier: getFieldFromLine(currentRecord, acceptedFields, 'sourceIdentifier') ?: getFieldFromLine(currentRecord, acceptedFields, 'titleId'),
-          sourceIdentifierNamespace: getFieldFromLine(currentRecord, acceptedFields, 'sourceIdentifierNamespace') ?: packageSource
+          sourceIdentifierNamespace: getFieldFromLine(currentRecord, acceptedFields, 'sourceIdentifierNamespace') ?: packageSource,
           syncContentsFromSource: true // This is defaulted right now, for more control the JSON import should be used
         )
         MDC.put('title', StringUtils.truncate(pkgLine.title))

--- a/service/grails-app/services/org/olf/ImportService.groovy
+++ b/service/grails-app/services/org/olf/ImportService.groovy
@@ -319,6 +319,7 @@ class ImportService implements DataBinder {
           firstEditor: getFieldFromLine(currentRecord, acceptedFields, 'firstEditor'),
           sourceIdentifier: getFieldFromLine(currentRecord, acceptedFields, 'sourceIdentifier') ?: getFieldFromLine(currentRecord, acceptedFields, 'titleId'),
           sourceIdentifierNamespace: getFieldFromLine(currentRecord, acceptedFields, 'sourceIdentifierNamespace') ?: packageSource
+          syncContentsFromSource: true // This is defaulted right now, for more control the JSON import should be used
         )
         MDC.put('title', StringUtils.truncate(pkgLine.title))
 

--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -333,16 +333,17 @@ class PackageIngestService implements DataBinder {
     if ( pkg == null ) {
       Org vendor = getVendorFromPackageData(package_data)
       pkg = new Pkg(
-                     name: package_data.header.packageName,
-                   source: package_data.header.packageSource,
-                reference: package_data.header.packageSlug,
-              description: package_data.header.description,
-        sourceDataCreated: package_data.header.sourceDataCreated,
-        sourceDataUpdated: package_data.header.sourceDataUpdated,
-         sourceTitleCount: package_data.header.sourceTitleCount,
-        availabilityScope: ( package_data.header.availabilityScope != null ? Pkg.lookupOrCreateAvailabilityScope(package_data.header.availabilityScope) : null ),
-          lifecycleStatus: Pkg.lookupOrCreateLifecycleStatus(package_data.header.lifecycleStatus != null ? package_data.header.lifecycleStatus : 'Unknown'),
-                   vendor: vendor,
+                          name: package_data.header.packageName,
+                        source: package_data.header.packageSource,
+                     reference: package_data.header.packageSlug,
+                   description: package_data.header.description,
+             sourceDataCreated: package_data.header.sourceDataCreated,
+             sourceDataUpdated: package_data.header.sourceDataUpdated,
+              sourceTitleCount: package_data.header.sourceTitleCount,
+        syncContentsFromSource: package_data.header.syncContentsFromSource,
+             availabilityScope: ( package_data.header.availabilityScope != null ? Pkg.lookupOrCreateAvailabilityScope(package_data.header.availabilityScope) : null ),
+               lifecycleStatus: Pkg.lookupOrCreateLifecycleStatus(package_data.header.lifecycleStatus != null ? package_data.header.lifecycleStatus : 'Unknown'),
+                        vendor: vendor,
       ).save(flush:true, failOnError:true)
 
       (package_data?.header?.contentTypes ?: []).each {

--- a/service/src/main/groovy/org/olf/dataimport/erm/ErmPackageImpl.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/erm/ErmPackageImpl.groovy
@@ -20,6 +20,7 @@ class ErmPackageImpl implements PackageHeaderSchema, PackageSchema, Validateable
 
   String source
   String reference
+  Boolean syncContentsFromSource
   String name
   PackageProvider packageProvider
   Boolean trustedSourceTI
@@ -38,7 +39,7 @@ class ErmPackageImpl implements PackageHeaderSchema, PackageSchema, Validateable
 
   Set<ContentItem> contentItems = []
 
-  // Defaults for internal scheam so we can make them optional in the constraints.
+  // Defaults for internal schema so we can make them optional in the constraints.
   final LocalDate startDate = null
   final LocalDate endDate = null
   final String _intenalId = null
@@ -54,6 +55,7 @@ class ErmPackageImpl implements PackageHeaderSchema, PackageSchema, Validateable
     _intenalId nullable: true, blank: false
     status nullable: true, blank: false
     trustedSourceTI nullable: true
+    syncContentsFromSource nullable: true
     description nullable: true
 
     source             nullable: false, blank: false

--- a/service/src/main/groovy/org/olf/dataimport/internal/HeaderImpl.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/HeaderImpl.groovy
@@ -22,6 +22,7 @@ class HeaderImpl implements PackageHeaderSchema, Validateable {
   String status
   String packageName
   Boolean trustedSourceTI
+  Boolean syncContentsFromSource = false
   LocalDate startDate
   LocalDate endDate
   String packageSlug

--- a/service/src/main/groovy/org/olf/dataimport/internal/PackageSchema.groovy
+++ b/service/src/main/groovy/org/olf/dataimport/internal/PackageSchema.groovy
@@ -68,6 +68,7 @@ interface PackageSchema extends Validateable {
     String getStatus()
     String get_intenalId()
     Boolean getTrustedSourceTI()
+    Boolean getSyncContentsFromSource()
     Date getSourceDataCreated()
     Date getSourceDataUpdated()
     Integer getSourceTitleCount()

--- a/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
+++ b/service/src/main/groovy/org/olf/kb/adapters/GOKbOAIAdapter.groovy
@@ -453,6 +453,7 @@ public class GOKbOAIAdapter extends WebSourceAdapter implements KBCacheUpdater, 
           packageSource:'GOKb',
           packageName: package_name,
           trustedSourceTI: trustedSourceTI,
+          syncContentsFromSource: true, // TODO this will eventually possibly not be hard coded to true
           packageSlug: primary_slug,
           sourceDataCreated: source_data_created,
           sourceDataUpdated: source_data_updated,


### PR DESCRIPTION
**feat: Pkg.syncContentsFromSource**
  - Created new boolean property on Pkg domain object: syncContentsFromSource. This defaults to `false` on Pkg creation.
  - Also added protection to prevent this field being set via Pkg PUT

**feat: ingest syncContentsFromSource=true**
  - Set syncContentsFromSource to true when harvesting via normal methods.

  - Add syncContentsFromSource to PackageSchema.HeaderSchema, so it is directly settable via JSON (defaults to false)

  - JSON import should default to false, but settable via the header
  - KBART imports should default to true