### PR TITLE
ERM-3470: fix -- remove S3 environment variable string fallback

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -199,7 +199,9 @@ bootRun {
     '-Dspring.output.ansi.enabled=always',
     '-noverify',
     '-XX:TieredStopAtLevel=1',
-    '-Xmx1592m')
+    //'-Xmx1374m'
+    '-Xmx1592m'
+  )
 	sourceResources sourceSets.main
 	String springProfilesActive = 'spring.profiles.active'
 	systemProperty springProfilesActive, System.getProperty(springProfilesActive)

--- a/service/grails-app/conf/application.yml
+++ b/service/grails-app/conf/application.yml
@@ -245,7 +245,7 @@ environments:
       filestore:
         aws_region: "${aws.region:us-east-1}"
         aws_url: "${aws.url}"
-        aws_secret: "${aws.secret.access.key:none}"
+        aws_secret: "${aws.secret.access.key}"
         aws_bucket: "${aws.bucket:none}"
         aws_access_key_id: "${aws.access.key.id:none}"
 

--- a/service/grails-app/services/org/olf/ErmHousekeepingService.groovy
+++ b/service/grails-app/services/org/olf/ErmHousekeepingService.groovy
@@ -63,7 +63,7 @@ public class ErmHousekeepingService {
             [ 'fileStorage', 'storageEngine', 'String', 'FileStorageEngines', 'LOB' ],
             [ 'fileStorage', 'S3Endpoint',    'String', null,                 default_aws_url ?: 'http://s3_endpoint_host.domain:9000' ],
             [ 'fileStorage', 'S3AccessKey',   'String', null,                 default_aws_access_key_id ?: 'ACCESS_KEY' ],
-            [ 'fileStorage', 'S3SecretKey',   'String', null,                 default_aws_secret ?: 'SECRET_KEY' ],
+            [ 'fileStorage', 'S3SecretKey',   'String', null,                 default_aws_secret ],
             [ 'fileStorage', 'S3BucketName',  'String', null,                 default_aws_bucket ?: "${tenantId}-shared" ],
             [ 'fileStorage', 'S3ObjectPrefix','String', null,                 "/${tenantId}/agreements/" ],
             [ 'fileStorage', 'S3BucketRegion','String', null,                 default_aws_region ],


### PR DESCRIPTION
build: Remove string fallbacks for S3 env variable

S3 environment variable should be `null` when it has not been configured.

refs ERM-3470