### PR TITLE
Bump memory recommendation in ModuleDescriptor

### DIFF
--- a/service/src/main/okapi/ModuleDescriptor-template.json
+++ b/service/src/main/okapi/ModuleDescriptor-template.json
@@ -2098,7 +2098,7 @@
     "dockerImage": "${info.app.name}:${info.app.version}",
     "dockerArgs": {
       "HostConfig": {
-        "Memory": 2147483648,
+        "Memory": 4294967296,
         "PortBindings": {
           "8080/tcp": [
             {


### PR DESCRIPTION
Following [PR in folio-ansible](https://github.com/folio-org/folio-ansible/pull/624) and investigation, the conclusion is that with the current method of harvest internally external factors outside of our control are causing enormous memory spikes.

We previously had packages that were no more than roughly 20k titles (in GOKb Test, which folio snapshot points at)

GOKb has added a package with ~60k titles, which via the XML OAI endpoint we use for harvesting amounts to ~250mb RAW XML data, and then ~2.5GB in memory once converted. Since it is XML the current approach is to read the entire thing into memory before processing.


Longer term, there may be mitigations we can approach, such as a custom parser which keeps the TIPP data in string form until we're ready to process it, only transforming the package headers. However that is beyond the scope of a refactor during release week, and thus the decision has been made to recommend that harvesting from a GOKb with packages this large necessitates ~2.5GB memory PER harvest concurrently running (The default is up to 2 tenants can harvest concurrently) This memory will not always be necessary, after the harvest of such large packages it could feasibly be lowered again for most operations, but any changes to such larges packages or their titles would cause OOMs again.