### PR TITLE
build: Include plugin to prevent liquibase locks from becoming unrecoverable

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -143,6 +143,10 @@ dependencies {
   }
   implementation 'org.liquibase:liquibase-core:4.19.0'
 
+  // Plugin to avoid liquibase session locking causing issues
+  implementation 'com.github.blagerweij:liquibase-sessionlock:1.6.9'
+
+
 
   implementation 'com.opencsv:opencsv:5.7.1'
   implementation 'commons-io:commons-io:2.7'


### PR DESCRIPTION
Includes `com.github.blagerweij:liquibase-sessionlock:1.6.9` plugin for preventing liquibase locking in postgres.

Additionally working on grails-okapi changes to mitigate some of the federated locking stuff as well

refs ERM-3631