### PR TITLE
ERM-3659: minio 8.5.17, kafka-clients 3.7.2, jackson 2.18.3 fixing vulns

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -71,6 +71,8 @@ repositories {
 	mavenCentral()
 }
 
+ext['jackson.version'] = '2.18.3'
+
 dependencies {
   /* Grails 6 */
   compileOnly("io.micronaut:micronaut-inject-groovy")
@@ -159,7 +161,7 @@ dependencies {
   implementation 'org.z3950.zing:cql-java:1.13'
 
   // Minio for file storage to S3
-  implementation "io.minio:minio:8.5.1"
+  implementation "io.minio:minio:8.5.17"
   implementation 'com.squareup.okhttp3:okhttp:4.10.0'
   implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.10'
 
@@ -174,7 +176,7 @@ dependencies {
 	implementation "org.seleniumhq.selenium:selenium-firefox-driver:3.14.0"
 
 	/* ---- Custom non profile deps ---- */
-	implementation 'org.apache.kafka:kafka-clients:3.7.0'
+	implementation 'org.apache.kafka:kafka-clients:3.7.2'
 	implementation 'com.github.everit-org.json-schema:org.everit.json.schema:1.14.4'
 	// Better test reports.
 	testImplementation( 'com.athaydes:spock-reports:2.3.2-groovy-3.0' ) {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/ERM-3659

Upgrade some dependencies of mod-agreements fixing vulnerabilities:

Upgrade io.minio:minio from 8.5.1 to 8.5.17.
Upgrade kafka-clients from 3.7.0 to 3.7.2.
Upgrade jackson from 2.13.5 to 2.18.3.

Note that minio 8.5.17 comes with jackson 2.18: https://github.com/minio/minio-java/blob/8.5.17/build.gradle#L57-L59

The kafka-clients upgrade fixes this vulnerability:

* CVE-2024-56128 SCRAM authentication replay attack https://github.com/advisories/GHSA-p7c9-8xx8-h74f

The jackson upgrade fixes this vulnerability:

* numeric type conversion DoS https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-7569538

The upgrades fix these vulnerabilities in transitive dependencies:

snappy-java from 1.1.8.4 to 1.1.10.5 fixing

* CVE-2023-34453 Integer Overflow or Wraparound in shuffle https://github.com/xerial/snappy-java/security/advisories/GHSA-pqr6-cmr2-h8hf
* CVE-2023-34454 Integer Overflow or Wraparound in compress https://github.com/xerial/snappy-java/security/advisories/GHSA-fjpj-2g6w-x25r
* CVE-2023-34455 Chunk length check OOM DoS https://github.com/xerial/snappy-java/security/advisories/GHSA-qcwq-55hx-v3vh
* CVE-2023-43642 Chunk length check OOM DoS https://github.com/xerial/snappy-java/security/advisories/GHSA-55g7-9cwv-5qfv

commons-compress from 1.21 to 1.27.1 fixing

* CVE-2024-25710 Infinite loop https://github.com/advisories/GHSA-4g9r-vxhx-9pgx
* CVE-2024-26308 Uncontrolled Resource Consumption with bad Pack200 file https://github.com/advisories/GHSA-4265-ccf5-phj5

from bcprov-jdk15on 1.69 to bcprov-jdk18on 1.78.1 fixing

* CVE-2023-33202 Uncontrolled Resource Consumption in PEMParser https://github.com/advisories/GHSA-wjxj-5m7g-mg7q
* CVE-2024-29857 Uncontrolled Resource Consumption in ECCurve.java https://github.com/advisories/GHSA-8xfc-gm6g-vgpv
* CVE-2023-33201 Information Exposure via Blind LDAP Injection https://github.com/advisories/GHSA-hr8g-6v94-x4m9