### PR TITLE
ERM-3660: Upgrade undertow 2.2.28.Final -> 2.2.37.Final fixing vulns

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -134,7 +134,21 @@ dependencies {
   implementation("io.micronaut:micronaut-http-client")
 
   implementation 'org.codehaus.janino:janino:3.1.9'
+
   implementation "org.springframework.boot:spring-boot-starter-undertow" // Replaces spring-boot-starter-tomcat
+  // security upgrade for undertow, using same exclusions as
+  // https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-starter-undertow/2.7.18/spring-boot-starter-undertow-2.7.18.pom
+  implementation("io.undertow:undertow-core:2.2.37.Final")
+  implementation("io.undertow:undertow-servlet:2.2.37.Final") {
+    exclude group: "org.jboss.spec.javax.servlet", module: "jboss-servlet-api_4.0_spec"
+    exclude group: "org.jboss.spec.javax.annotation", module: "jboss-annotations-api_1.3_spec"
+  }
+  implementation("io.undertow:undertow-websockets-jsr:2.2.37.Final") {
+    exclude group: "org.jboss.spec.javax.websocket", module: "jboss-websocket-api_1.1_spec"
+    exclude group: "org.jboss.spec.javax.servlet", module: "jboss-servlet-api_4.0_spec"
+    exclude group: "org.jboss.spec.javax.annotation", module: "jboss-annotations-api_1.3_spec"
+  }
+
   implementation "org.hibernate:hibernate-java8"
   runtimeOnly "com.zaxxer:HikariCP:5.1.0"                             // Replaces Tomcat JDBC pool
   runtimeOnly "org.postgresql:postgresql:42.7.3"


### PR DESCRIPTION
Upgrade mod-agreements by bumping the undertow dependencies.

mod-agreements 7.2.0 has these productionRuntimeClasspath undertow dependencies:

```
+--- org.springframework.boot:spring-boot-starter-undertow -> 2.7.18
|    +--- io.undertow:undertow-core:2.2.28.Final
|    |    +--- org.jboss.logging:jboss-logging:3.4.1.Final -> 3.4.3.Final
|    |    +--- org.jboss.xnio:xnio-api:3.8.7.Final
|    |    |    +--- org.wildfly.common:wildfly-common:1.5.4.Final
|    |    |    +--- org.wildfly.client:wildfly-client-config:1.0.1.Final
|    |    |    |    \--- org.jboss.logging:jboss-logging:3.3.1.Final -> 3.4.3.Final
|    |    |    \--- org.jboss.threads:jboss-threads:2.3.6.Final -> 3.1.0.Final
|    |    |         +--- org.jboss.logging:jboss-logging:3.4.1.Final -> 3.4.3.Final
|    |    |         \--- org.wildfly.common:wildfly-common:1.5.0.Final -> 1.5.4.Final
|    |    +--- org.jboss.xnio:xnio-nio:3.8.7.Final
|    |    |    \--- org.jboss.xnio:xnio-api:3.8.7.Final (*)
|    |    \--- org.jboss.threads:jboss-threads:3.1.0.Final (*)
|    +--- io.undertow:undertow-servlet:2.2.28.Final
|    |    \--- io.undertow:undertow-core:2.2.28.Final (*)
|    +--- io.undertow:undertow-websockets-jsr:2.2.28.Final
|    |    +--- io.undertow:undertow-core:2.2.28.Final (*)
|    |    \--- io.undertow:undertow-servlet:2.2.28.Final (*)
|    +--- jakarta.servlet:jakarta.servlet-api:4.0.4
|    +--- jakarta.websocket:jakarta.websocket-api:1.1.2
|    \--- org.apache.tomcat.embed:tomcat-embed-el:9.0.83
```

undertow-core:2.2.28.Final has 10 security vulnerabilities: https://security.snyk.io/package/maven/io.undertow%3Aundertow-core/2.2.28.Final

org.springframework.boot:spring-boot-starter-undertow:2.7.18 is the last 2.7.x release of spring-boot-starter-undertow, therefore we need to bump the io.undertow versions.

Result after this upgrade:

```
+--- org.springframework.boot:spring-boot-starter-undertow -> 2.7.18
|    +--- io.undertow:undertow-core:2.2.28.Final -> 2.2.37.Final
|    |    +--- org.jboss.logging:jboss-logging:3.4.1.Final -> 3.4.3.Final
|    |    +--- org.jboss.xnio:xnio-api:3.8.16.Final
|    |    |    +--- org.wildfly.common:wildfly-common:1.5.4.Final
|    |    |    +--- org.wildfly.client:wildfly-client-config:1.0.1.Final
|    |    |    |    \--- org.jboss.logging:jboss-logging:3.3.1.Final -> 3.4.3.Final
|    |    |    \--- org.jboss.threads:jboss-threads:2.3.6.Final -> 3.1.0.Final
|    |    |         +--- org.jboss.logging:jboss-logging:3.4.1.Final -> 3.4.3.Final
|    |    |         \--- org.wildfly.common:wildfly-common:1.5.0.Final -> 1.5.4.Final
|    |    +--- org.jboss.xnio:xnio-nio:3.8.16.Final
|    |    |    \--- org.jboss.xnio:xnio-api:3.8.16.Final (*)
|    |    \--- org.jboss.threads:jboss-threads:3.1.0.Final (*)
|    +--- io.undertow:undertow-servlet:2.2.28.Final -> 2.2.37.Final
|    |    \--- io.undertow:undertow-core:2.2.37.Final (*)
|    +--- io.undertow:undertow-websockets-jsr:2.2.28.Final -> 2.2.37.Final
|    |    +--- io.undertow:undertow-core:2.2.37.Final (*)
|    |    \--- io.undertow:undertow-servlet:2.2.37.Final (*)
|    +--- jakarta.servlet:jakarta.servlet-api:4.0.4
|    +--- jakarta.websocket:jakarta.websocket-api:1.1.2
|    \--- org.apache.tomcat.embed:tomcat-embed-el:9.0.83
+--- io.undertow:undertow-core:2.2.37.Final (*)
+--- io.undertow:undertow-servlet:2.2.37.Final (*)
+--- io.undertow:undertow-websockets-jsr:2.2.37.Final (*)
```