### PR TITLE
feat: (WIP) Initial attempt at Affiliation/Grant modelling.

### DIFF
--- a/service/grails-app/domain/org/olf/rbac/Affiliation.groovy
+++ b/service/grails-app/domain/org/olf/rbac/Affiliation.groovy
@@ -1,0 +1,28 @@
+package org.olf.rbac
+
+import grails.gorm.MultiTenant
+
+public class Affiliation implements MultiTenant<Affiliation> {
+  String id
+
+  String user // A FOLIO UUID for a given user. No foreign key as this user is in a DIFFERENT schema
+  AffiliationRole role // An enum for sysops vs admin etc
+
+  // FIXME This is confusing to me at the moment
+  // Users can have different roles in different systems.
+  // Do we need a grantContext as well? But that will repeat information potentially
+  String party // A carefully constructed party string, such as GBVShared1/UB-Rostock/Medical
+
+  // FIXME tbd how does this EXACTLY link to Acq groups?
+
+  static mapping = {
+    id      column: 'aff_id', generator: 'uuid2', length:36
+    version column: 'aff_version'
+    user    column: 'aff_user'
+    role    column: 'aff_role'
+    party   column: 'aff_party'
+  }
+
+  static constraints = {
+  }
+}

--- a/service/grails-app/domain/org/olf/rbac/Grant.groovy
+++ b/service/grails-app/domain/org/olf/rbac/Grant.groovy
@@ -1,0 +1,61 @@
+package org.olf.rbac
+
+import grails.gorm.MultiTenant
+
+public class Grant implements MultiTenant<Grant> {
+  String id
+
+  /* ------- GRANT ON WHAT ----- */
+  // This object grants access to resources matching the below
+  /*
+    | party (resource.owner) | resourceType          | resourceId || explanation                                                 |
+    | ---------------------- | --------------------- | ---------- || ----------------------------------------------------------- |
+    | %                      | %                     | 1234-5678  || Matches any resource with the id "1234-5678"                |
+    | Org/Dept               | %                     | %          || Matches any resource owned specifically by Org/Dept         |
+    | Org/Dept%              | %                     | %          || Matches any resource owned Org/Dept or children             |
+    | Org/Dept/%             | %                     | %          || Matches any resource owned by children of Org/Dept only     |
+    | %                      | %                     | %          || Matches every resource in the system                        |
+    | %                      | SubscriptionAgreement | %          || Matches all SubscriptionAgreements in the system            |
+    | Org%                   | SubscriptionAgreement | %          || Matches all SubscriptionAgreements owned by Org or children |
+   */
+
+  String resourceType // A class string or %
+  // FIXME could this potentially handle packages? org.olf.% for example
+  String resourceId // Either an individual id or %
+  String party // A structured party string, as per Affiliation AND resource owner fields.
+
+  /* ------- GRANT TO WHOM ----- */
+  // This object grants access to users matching the below
+  // FIXME see Affiliation, there's a strange crossover between resource owner and role-in-party
+  // We might want to grant special access to SubscriptionAgreements in /Org/Dept1 to people who are admins in Org/Dept2?
+  // We could give them both "Admin" role at Org level, but if they're only allowed to access each other's Agreements (and not, say Org/Dept3's)
+  // then we potentially have an issue. granteeContext allows us to do this, but does seem to overcomplicate matters :/
+
+  // That would look like
+  // granteeType: ROLE, granteeId: ADMIN, granteeContext: Org/Dept2 pointing at
+  // resource.owner Org/Dept1, resourceType: SubscriptionAgreement
+  /*
+    | granteeType | granteeId | granteeContext || explanation                      |
+    | ----------- | --------- | -------------- || -------------------------------- |
+    | %           | %         | %              ||  Matches all users in the system |
+    | ROLE        | %         | %              ||  ??                              |
+
+   */
+  GranteeType granteeType // An enum for role vs group vs user etc
+  String granteeId // Depends on "granteeType" above.
+  // For USER this will be a UUID
+  // For ROLE this would be one of AffiliationRole
+  // For GROUP this will be // FIXME What will this be??? -- is this where acquisition groups come in or no?
+
+
+  static mapping = {
+    id           column: 'gra_id', generator: 'uuid2', length:36
+    version      column: 'gra_version'
+    resourceType column: 'gra_resource_type'
+    resourceId   column: 'gra_resource_id'
+    party        column: 'gra_party'
+  }
+
+  static constraints = {
+  }
+}

--- a/service/src/main/groovy/org/olf/rbac/AffiliationRole.java
+++ b/service/src/main/groovy/org/olf/rbac/AffiliationRole.java
@@ -1,0 +1,7 @@
+package org.olf.rbac;
+
+public enum AffiliationRole {
+  SYSOPS,
+  ADMIN,
+  USER,
+}

--- a/service/src/main/groovy/org/olf/rbac/GranteeType.java
+++ b/service/src/main/groovy/org/olf/rbac/GranteeType.java
@@ -1,0 +1,7 @@
+package org.olf.rbac;
+
+public enum GranteeType {
+  ROLE,
+  USER,
+  GROUP
+}

--- a/service/src/main/groovy/org/olf/rbac/RBACImplementer.java
+++ b/service/src/main/groovy/org/olf/rbac/RBACImplementer.java
@@ -1,0 +1,8 @@
+package org.olf.rbac;
+
+// Implemented by any domain class implementing our RBAC implementation
+public interface RBACImplementer {
+  public default String rbacDBColumn() {
+    return "rbac_owner";
+  }
+}


### PR DESCRIPTION
This needs some serious thought. Open questions:

- How does this link up to Acquisitions Groups
- What to do about granteeContext
  - Without it we don't have a way to distinguish roles
  - But is it the pattern or is that on the Affiliation?
- Where do the "party" options come from?
  - In [the white paper](https://docs.google.com/document/d/1J6k7Wzxs1EbgNHXGlvoZE5QCeQQvXgovnHYBKJ2tab0/edit?tab=t.0) the Directory module is name checked
  - But this module is part of ILL and is licensed differently
  - Do we need something logically similar (for future ability to combine) or avoid entirely for now?
- What is the structure of "permissions" and "permission groups"
  - Do these in _any_ way correspond to FOLIO permissions (API perms) or are we constructing something new?