### PR TITLE
ERM-3720: Error on attempting to retrieve e-resources for an agreement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ tools/testing/zk-single-kafka-single
 !.keep
 
 *.iml
+
+**/.idea/*


### PR DESCRIPTION
fix: Replace deduplicating IN clause with subquery

Swapped from a List of resource ids to an HQL subquery. This avoids binding more than 62k params in the current worst case scenario.

Still need the subquery in order to perform deduplication (I guess DISTINCT didn't work previously, but I'm not sure why there's no comment)

Also added `.idea` directories ANYWHERE in the module tree to gitignore

ERM-3720: Error on attempting to retrieve e-resources for an agreement