### PR TITLE
ERM-3726: Fix publicLookup API behaviour for access & active from/to dates for PCI based agreement lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ tools/testing/zk-single-kafka-single
 !.keep
 
 *.iml
+
+**/.idea/*

--- a/service/grails-app/controllers/org/olf/SubscriptionAgreementController.groovy
+++ b/service/grails-app/controllers/org/olf/SubscriptionAgreementController.groovy
@@ -147,15 +147,7 @@ class SubscriptionAgreementController extends OkapiTenantAwareController<Subscri
                     ge 'activeTo', today
                   }
                 }
-                or {
-                  isNull 'accessStart'
-                  le 'accessStart', today
-                }
-                or {
-                  isNull 'accessEnd'
-                  ge 'accessEnd', today
-                }
-                  
+
                 projections {
                   property ('id')
                 }

--- a/service/src/integration-test/groovy/org/olf/Agreements/AgreementPublicLookupSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/Agreements/AgreementPublicLookupSpec.groovy
@@ -1,114 +1,16 @@
 package org.olf.Agreements
 import grails.testing.mixin.integration.Integration
 import groovy.util.logging.Slf4j
-import org.olf.BaseSpec
 import org.olf.kb.PackageContentItem
 import org.olf.kb.Pkg
 import spock.lang.Ignore
 import spock.lang.Shared
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
-import org.olf.erm.SubscriptionAgreement
 
 @Integration
 @Slf4j
-class AgreementPublicLookupSpec extends BaseSpec {
+class AgreementPublicLookupSpec extends AgreementsBaseSpec {
   @Shared
   String pkg_id
-
-
-  @Ignore
-  Map createAgreement(String name="test_agreement") {
-    def today = LocalDate.now()
-    def tomorrow = today.plusDays(1)
-
-    def payload = [
-      periods: [
-        [
-          startDate: today.format(DateTimeFormatter.ISO_LOCAL_DATE),
-          endDate: tomorrow.format(DateTimeFormatter.ISO_LOCAL_DATE)
-        ]
-      ],
-      name: name,
-      agreementStatus: "active"
-    ]
-
-    def response = doPost("/erm/sas/", payload)
-
-    return response as Map
-  }
-
-  @Ignore
-  Map addEntitlementForAgreement(String agreementName, String resourceId) {
-    String agreement_id;
-    withTenant {
-      String hql = """
-            SELECT agreement.id 
-            FROM SubscriptionAgreement agreement 
-            WHERE agreement.name = :agreementName 
-        """
-      List results = SubscriptionAgreement.executeQuery(hql, [agreementName: agreementName])
-      agreement_id = results.get(0)
-    }
-
-
-    return doPut("/erm/sas/${agreement_id}", {
-      items ([
-        {
-          resource {
-            id resourceId
-          }
-        }
-      ])
-    }) as Map
-  }
-
-  @Ignore
-  String getAgreementIdByName(String agreementName) {
-    String agreement_id;
-    withTenant {
-      String hql = """
-            SELECT agreement.id 
-            FROM SubscriptionAgreement agreement 
-            WHERE agreement.name = :agreementName 
-        """
-      List results = SubscriptionAgreement.executeQuery(hql, [agreementName: agreementName])
-      agreement_id = results.get(0)
-    }
-    return agreement_id
-  }
-
-  Pkg findPkgByPackageName(String packageName) {
-    log.info("Package name: " + packageName)
-    withTenant {
-      String hql = """
-            SELECT package
-            FROM Pkg package
-            WHERE package.name = :packageName
-        """
-      List results = Pkg.executeQuery(hql, [packageName: packageName])
-      if (results.size() > 1) {
-        throw new IllegalStateException("Multiple Packages found for package name ${packageName}, one expected.")
-      }
-      return results.get(0);
-    }
-  }
-
-  PackageContentItem findPCIByPackageName(String packageName, String titleName) {
-    withTenant {
-      String hql = """
-            SELECT pci
-            FROM PackageContentItem pci
-            WHERE pci.pkg.name = :packageName
-            AND pci.pti.titleInstance.work.title = :titleName
-        """
-      List results = PackageContentItem.executeQuery(hql, [packageName: packageName, titleName: titleName])
-      if (results.size() > 1) {
-        throw new IllegalStateException("Multiple PCIs found for package name ${packageName}, one expected.")
-      }
-      return results.get(0);
-    }
-  }
 
   @Ignore
   void assertAgreements(String resourceId, Set<String> expectedAgreements) {
@@ -149,187 +51,188 @@ class AgreementPublicLookupSpec extends BaseSpec {
   void "Load Packages"() {
 
     when: 'File loaded'
-    Map result = importPackageFromFileViaService('publicLookup/publicLookupPackage1.json')
-    importPackageFromFileViaService('publicLookup/publicLookupPackage2.json')
-    importPackageFromFileViaService('publicLookup/publicLookupPackage3.json')
-    importPackageFromFileViaService('publicLookup/publicLookupPackage4.json')
-    importPackageFromFileViaService('publicLookup/publicLookupPackage5.json')
-    importPackageFromFileViaService('publicLookup/publicLookupPackage6.json')
+      Map result = importPackageFromFileViaService('publicLookup/publicLookupPackage1.json')
+      importPackageFromFileViaService('publicLookup/publicLookupPackage2.json')
+      importPackageFromFileViaService('publicLookup/publicLookupPackage3.json')
+      importPackageFromFileViaService('publicLookup/publicLookupPackage4.json')
+      importPackageFromFileViaService('publicLookup/publicLookupPackage5.json')
+      importPackageFromFileViaService('publicLookup/publicLookupPackage6.json')
+
     then: 'Package imported'
-    result.packageImported == true
+      result.packageImported == true
 
     when: "Looked up package with name"
-    List resp = doGet("/erm/packages", [filters: ['name==test_package_1']])
-    doGet("/erm/packages", [filters: ['name==test_package_2']])
-    doGet("/erm/packages", [filters: ['name==test_package_3']])
-    doGet("/erm/packages", [filters: ['name==test_package_4']])
-    doGet("/erm/packages", [filters: ['name==test_package_5']])
-    doGet("/erm/packages", [filters: ['name==test_package_6']])
-    pkg_id = resp[0].id
+      List resp = doGet("/erm/packages", [filters: ['name==test_package_1']])
+      doGet("/erm/packages", [filters: ['name==test_package_2']])
+      doGet("/erm/packages", [filters: ['name==test_package_3']])
+      doGet("/erm/packages", [filters: ['name==test_package_4']])
+      doGet("/erm/packages", [filters: ['name==test_package_5']])
+      doGet("/erm/packages", [filters: ['name==test_package_6']])
+      pkg_id = resp[0].id
 
     then: "Package found"
-    log.info(resp.toListString())
-    resp.size() == 1
-    resp[0].id != null
+      log.info(resp.toListString())
+      resp.size() == 1
+      resp[0].id != null
   }
 
   void "Create Agreements and lines"() {
 
     when:
-    test_package_1 = findPkgByPackageName("test_package_1")
-    createAgreement("Agreement A")
-    addEntitlementForAgreement("Agreement A", test_package_1.id)
+      test_package_1 = findPkgByPackageName("test_package_1")
+      createAgreement("Agreement A")
+      addEntitlementForAgreement("Agreement A", test_package_1.id)
 
-    test_package_1_pci = findPCIByPackageName("test_package_1", "Academy of Management Learning & Education")
-    createAgreement("Agreement B")
-    addEntitlementForAgreement("Agreement B", test_package_1_pci.id)
+      test_package_1_pci = findPCIByPackageName("test_package_1", "Academy of Management Learning & Education")
+      createAgreement("Agreement B")
+      addEntitlementForAgreement("Agreement B", test_package_1_pci.id)
 
-    createAgreement("Agreement C")
-    Pkg test_package_6 = findPkgByPackageName("test_package_6")
-    addEntitlementForAgreement("Agreement C", test_package_6.id)
+      createAgreement("Agreement C")
+      Pkg test_package_6 = findPkgByPackageName("test_package_6")
+      addEntitlementForAgreement("Agreement C", test_package_6.id)
 
-    createAgreement("Agreement D")
-    PackageContentItem test_package_6_pci = findPCIByPackageName("test_package_6", "Academy of Management Learning & Education")
-    addEntitlementForAgreement("Agreement D", test_package_6_pci.id)
+      createAgreement("Agreement D")
+      PackageContentItem test_package_6_pci = findPCIByPackageName("test_package_6", "Academy of Management Learning & Education")
+      addEntitlementForAgreement("Agreement D", test_package_6_pci.id)
 
-    createAgreement("Agreement E")
-    Pkg test_package_2 = findPkgByPackageName("test_package_2")
-    addEntitlementForAgreement("Agreement E", test_package_2.id)
+      createAgreement("Agreement E")
+      Pkg test_package_2 = findPkgByPackageName("test_package_2")
+      addEntitlementForAgreement("Agreement E", test_package_2.id)
 
-    createAgreement("Agreement F")
-    PackageContentItem test_package_2_pci = findPCIByPackageName("test_package_2", "Academy of Management Learning & Education")
-    addEntitlementForAgreement("Agreement F", test_package_2_pci.id)
+      createAgreement("Agreement F")
+      PackageContentItem test_package_2_pci = findPCIByPackageName("test_package_2", "Academy of Management Learning & Education")
+      addEntitlementForAgreement("Agreement F", test_package_2_pci.id)
 
-    pci1Id = test_package_1_pci.id
-    pti1Id = test_package_1_pci.pti.id
-    ti1Id = test_package_1_pci.pti.titleInstance.id
+      pci1Id = test_package_1_pci.id
+      pti1Id = test_package_1_pci.pti.id
+      ti1Id = test_package_1_pci.pti.titleInstance.id
 
-    pci2Id = test_package_2_pci.id
-    pti2Id = test_package_2_pci.pti.id
-    ti2Id = test_package_2_pci.pti.titleInstance.id
+      pci2Id = test_package_2_pci.id
+      pti2Id = test_package_2_pci.pti.id
+      ti2Id = test_package_2_pci.pti.titleInstance.id
 
     then:
-    log.debug("PCI ID: {}", pci1Id)
-    Set pciExpected = ["Agreement A", "Agreement B"] as Set
-    assertAgreements(pci1Id, pciExpected)
+      log.debug("PCI ID: {}", pci1Id)
+      Set pciExpected = ["Agreement A", "Agreement B"] as Set
+      assertAgreements(pci1Id, pciExpected)
 
-    log.debug("PTI ID: {}", pti1Id)
-    Set ptiExpected = ["Agreement A", "Agreement B", "Agreement D", "Agreement F"] as Set
-    assertAgreements(pti1Id, ptiExpected)
+      log.debug("PTI ID: {}", pti1Id)
+      Set ptiExpected = ["Agreement A", "Agreement B", "Agreement D", "Agreement F"] as Set
+      assertAgreements(pti1Id, ptiExpected)
 
-    log.debug("TI ID: {}", ti1Id)
-    Set tiExpected = ["Agreement A", "Agreement B", "Agreement D", "Agreement F"] as Set
-    assertAgreements(ti1Id, tiExpected)
+      log.debug("TI ID: {}", ti1Id)
+      Set tiExpected = ["Agreement A", "Agreement B", "Agreement D", "Agreement F"] as Set
+      assertAgreements(ti1Id, tiExpected)
   }
 
   void "Agreement B activeTo date in the past"() {
 
     when:
-    String agreement_id = getAgreementIdByName("Agreement B")
-    Map httpResult = doGet("/erm/sas/${agreement_id}", [expand: 'items'])
-    def index = httpResult.items.findIndexOf{ it.resource?.id == test_package_1_pci.id }
-    httpResult.items[index].activeFrom = "${thisYear - 2}-01-01"
-    httpResult.items[index].activeTo = "${thisYear -1}-12-31"
-    httpResult = doPut("/erm/sas/${agreement_id}", httpResult, [expand: 'items'])
+      String agreement_id = getAgreementIdByName("Agreement B")
+      Map httpResult = doGet("/erm/sas/${agreement_id}", [expand: 'items'])
+      def index = httpResult.items.findIndexOf{ it.resource?.id == test_package_1_pci.id }
+      httpResult.items[index].activeFrom = "${thisYear - 2}-01-01"
+      httpResult.items[index].activeTo = "${thisYear -1}-12-31"
+      httpResult = doPut("/erm/sas/${agreement_id}", httpResult, [expand: 'items'])
 
     then:
-    log.debug("PCI ID: {}", pci1Id)
-    Set pciExpected = ["Agreement A"] as Set
-    assertAgreements(pci1Id, pciExpected)
+      log.debug("PCI ID: {}", pci1Id)
+      Set pciExpected = ["Agreement A"] as Set
+      assertAgreements(pci1Id, pciExpected)
 
-    log.debug("PTI ID: {}", pti1Id)
-    Set ptiExpected = ["Agreement A", "Agreement D", "Agreement F"] as Set
-    assertAgreements(pti1Id, ptiExpected)
+      log.debug("PTI ID: {}", pti1Id)
+      Set ptiExpected = ["Agreement A", "Agreement D", "Agreement F"] as Set
+      assertAgreements(pti1Id, ptiExpected)
 
-    log.debug("TI ID: {}", ti1Id)
-    Set tiExpected = ["Agreement A", "Agreement D", "Agreement F"] as Set
-    assertAgreements(ti1Id, tiExpected)
+      log.debug("TI ID: {}", ti1Id)
+      Set tiExpected = ["Agreement A", "Agreement D", "Agreement F"] as Set
+      assertAgreements(ti1Id, tiExpected)
 
   }
 
   void "Agreement B activeFrom date in the future and no activeTo date"() {
     when:
-    String agreement_id = getAgreementIdByName("Agreement B")
-    Map httpResult = doGet("/erm/sas/${agreement_id}", [expand: 'items'])
-    def index = httpResult.items.findIndexOf{ it.resource?.id == test_package_1_pci.id }
-    httpResult.items[index].activeFrom = "${thisYear + 1}-01-01"
-    httpResult.items[index].activeTo = ""
-    httpResult = doPut("/erm/sas/${agreement_id}", httpResult, [expand: 'items'])
+      String agreement_id = getAgreementIdByName("Agreement B")
+      Map httpResult = doGet("/erm/sas/${agreement_id}", [expand: 'items'])
+      def index = httpResult.items.findIndexOf{ it.resource?.id == test_package_1_pci.id }
+      httpResult.items[index].activeFrom = "${thisYear + 1}-01-01"
+      httpResult.items[index].activeTo = ""
+      httpResult = doPut("/erm/sas/${agreement_id}", httpResult, [expand: 'items'])
 
     then:
-    log.debug("PCI ID: {}", pci1Id)
-    Set pciExpected = ["Agreement A"] as Set
-    assertAgreements(pci1Id, pciExpected)
+      log.debug("PCI ID: {}", pci1Id)
+      Set pciExpected = ["Agreement A"] as Set
+      assertAgreements(pci1Id, pciExpected)
 
-    log.debug("PTI ID: {}", pti1Id)
-    Set ptiExpected = ["Agreement A", "Agreement D", "Agreement F"] as Set
-    assertAgreements(pti1Id, ptiExpected)
+      log.debug("PTI ID: {}", pti1Id)
+      Set ptiExpected = ["Agreement A", "Agreement D", "Agreement F"] as Set
+      assertAgreements(pti1Id, ptiExpected)
 
-    log.debug("TI ID: {}", ti1Id)
-    Set tiExpected = ["Agreement A", "Agreement D", "Agreement F"] as Set
-    assertAgreements(ti1Id, tiExpected)
+      log.debug("TI ID: {}", ti1Id)
+      Set tiExpected = ["Agreement A", "Agreement D", "Agreement F"] as Set
+      assertAgreements(ti1Id, tiExpected)
 
   }
 
   void "Agreement B no active to/active from dates, Agreement A has activeTo date in the past"() {
     when:
-    String agreementBId = getAgreementIdByName("Agreement B")
-    String agreementAId = getAgreementIdByName("Agreement A")
-    Map httpResultAgreementB = doGet("/erm/sas/${agreementBId}", [expand: 'items'])
-    Map httpResultAgreementA = doGet("/erm/sas/${agreementAId}", [expand: 'items'])
+      String agreementBId = getAgreementIdByName("Agreement B")
+      String agreementAId = getAgreementIdByName("Agreement A")
+      Map httpResultAgreementB = doGet("/erm/sas/${agreementBId}", [expand: 'items'])
+      Map httpResultAgreementA = doGet("/erm/sas/${agreementAId}", [expand: 'items'])
 
-    def indexB = httpResultAgreementB.items.findIndexOf{ it.resource?.id == test_package_1_pci.id }
-    httpResultAgreementB.items[indexB].activeFrom = ""
-    httpResultAgreementB.items[indexB].activeTo = ""
-    httpResultAgreementB = doPut("/erm/sas/${agreementBId}", httpResultAgreementB, [expand: 'items'])
+      def indexB = httpResultAgreementB.items.findIndexOf{ it.resource?.id == test_package_1_pci.id }
+      httpResultAgreementB.items[indexB].activeFrom = ""
+      httpResultAgreementB.items[indexB].activeTo = ""
+      httpResultAgreementB = doPut("/erm/sas/${agreementBId}", httpResultAgreementB, [expand: 'items'])
 
-    def indexA = httpResultAgreementA.items.findIndexOf{ it.resource?.id == test_package_1.id }
-    httpResultAgreementA.items[indexA].activeTo = "${thisYear -1}-12-31"
-    httpResultAgreementA = doPut("/erm/sas/${agreementAId}", httpResultAgreementA, [expand: 'items'])
+      def indexA = httpResultAgreementA.items.findIndexOf{ it.resource?.id == test_package_1.id }
+      httpResultAgreementA.items[indexA].activeTo = "${thisYear -1}-12-31"
+      httpResultAgreementA = doPut("/erm/sas/${agreementAId}", httpResultAgreementA, [expand: 'items'])
 
     then:
-    log.debug("PCI ID: {}", pci1Id)
-    Set pciExpected = ["Agreement B"] as Set
-    assertAgreements(pci1Id, pciExpected)
+      log.debug("PCI ID: {}", pci1Id)
+      Set pciExpected = ["Agreement B"] as Set
+      assertAgreements(pci1Id, pciExpected)
 
-    log.debug("PTI ID: {}", pti1Id)
-    Set ptiExpected = ["Agreement B", "Agreement D", "Agreement F"] as Set
-    assertAgreements(pti1Id, ptiExpected)
+      log.debug("PTI ID: {}", pti1Id)
+      Set ptiExpected = ["Agreement B", "Agreement D", "Agreement F"] as Set
+      assertAgreements(pti1Id, ptiExpected)
 
-    log.debug("TI ID: {}", ti1Id)
-    Set tiExpected = ["Agreement B", "Agreement D", "Agreement F"] as Set
-    assertAgreements(ti1Id, tiExpected)
+      log.debug("TI ID: {}", ti1Id)
+      Set tiExpected = ["Agreement B", "Agreement D", "Agreement F"] as Set
+      assertAgreements(ti1Id, tiExpected)
   }
 
   void "Agreement A has activeFrom date in future and no activeTo date."() {
     when:
-    String agreementBId = getAgreementIdByName("Agreement B")
-    String agreementAId = getAgreementIdByName("Agreement A")
-    Map httpResultAgreementB = doGet("/erm/sas/${agreementBId}", [expand: 'items'])
-    Map httpResultAgreementA = doGet("/erm/sas/${agreementAId}", [expand: 'items'])
+      String agreementBId = getAgreementIdByName("Agreement B")
+      String agreementAId = getAgreementIdByName("Agreement A")
+      Map httpResultAgreementB = doGet("/erm/sas/${agreementBId}", [expand: 'items'])
+      Map httpResultAgreementA = doGet("/erm/sas/${agreementAId}", [expand: 'items'])
 
-    def indexB = httpResultAgreementB.items.findIndexOf{ it.resource?.id == test_package_1_pci.id }
-    httpResultAgreementB.items[indexB].activeFrom = ""
-    httpResultAgreementB.items[indexB].activeTo = ""
-    httpResultAgreementB = doPut("/erm/sas/${agreementBId}", httpResultAgreementB, [expand: 'items'])
+      def indexB = httpResultAgreementB.items.findIndexOf{ it.resource?.id == test_package_1_pci.id }
+      httpResultAgreementB.items[indexB].activeFrom = ""
+      httpResultAgreementB.items[indexB].activeTo = ""
+      httpResultAgreementB = doPut("/erm/sas/${agreementBId}", httpResultAgreementB, [expand: 'items'])
 
-    def indexA = httpResultAgreementA.items.findIndexOf{ it.resource?.id == test_package_1.id }
-    httpResultAgreementA.items[indexA].activeTo = ""
-    httpResultAgreementA.items[indexA].activeFrom = "${thisYear + 1}-12-31"
-    httpResultAgreementA = doPut("/erm/sas/${agreementAId}", httpResultAgreementA, [expand: 'items'])
+      def indexA = httpResultAgreementA.items.findIndexOf{ it.resource?.id == test_package_1.id }
+      httpResultAgreementA.items[indexA].activeTo = ""
+      httpResultAgreementA.items[indexA].activeFrom = "${thisYear + 1}-12-31"
+      httpResultAgreementA = doPut("/erm/sas/${agreementAId}", httpResultAgreementA, [expand: 'items'])
 
     then:
-    log.debug("PCI ID: {}", pci1Id)
-    Set pciExpected = ["Agreement B"] as Set
-    assertAgreements(pci1Id, pciExpected)
+      log.debug("PCI ID: {}", pci1Id)
+      Set pciExpected = ["Agreement B"] as Set
+      assertAgreements(pci1Id, pciExpected)
 
-    log.debug("PTI ID: {}", pti1Id)
-    Set ptiExpected = ["Agreement B", "Agreement D", "Agreement F"] as Set
-    assertAgreements(pti1Id, ptiExpected)
+      log.debug("PTI ID: {}", pti1Id)
+      Set ptiExpected = ["Agreement B", "Agreement D", "Agreement F"] as Set
+      assertAgreements(pti1Id, ptiExpected)
 
-    log.debug("TI ID: {}", ti1Id)
-    Set tiExpected = ["Agreement B", "Agreement D", "Agreement F"] as Set
-    assertAgreements(ti1Id, tiExpected)
+      log.debug("TI ID: {}", ti1Id)
+      Set tiExpected = ["Agreement B", "Agreement D", "Agreement F"] as Set
+      assertAgreements(ti1Id, tiExpected)
 
   }
 }

--- a/service/src/integration-test/groovy/org/olf/Agreements/AgreementPublicLookupSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/Agreements/AgreementPublicLookupSpec.groovy
@@ -1,28 +1,223 @@
 package org.olf.Agreements
 import grails.testing.mixin.integration.Integration
+import groovy.util.logging.Slf4j
 import org.olf.BaseSpec
+import org.olf.kb.PackageContentItem
+import org.olf.kb.Pkg
+import spock.lang.Ignore
 import spock.lang.Shared
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import org.olf.erm.SubscriptionAgreement
+import org.olf.erm.Entitlement
 
 @Integration
+@Slf4j
 class AgreementPublicLookupSpec extends BaseSpec {
   @Shared
   String pkg_id
+
+
+  @Ignore
+  Map createAgreement(String name="test_agreement") {
+    def today = LocalDate.now()
+    def tomorrow = today.plusDays(1)
+
+    def payload = [
+      periods: [
+        [
+          startDate: today.format(DateTimeFormatter.ISO_LOCAL_DATE),
+          endDate: tomorrow.format(DateTimeFormatter.ISO_LOCAL_DATE)
+        ]
+      ],
+      name: name,
+      agreementStatus: "active"
+    ]
+
+    def response = doPost("/erm/sas/", payload)
+
+    return response as Map
+  }
+
+  @Ignore
+  Map addEntitlementForAgreement(String agreementName, String resourceId) {
+    String agreement_id;
+    withTenant {
+      String hql = """
+            SELECT agreement.id 
+            FROM SubscriptionAgreement agreement 
+            WHERE agreement.name = :agreementName 
+        """
+      List results = SubscriptionAgreement.executeQuery(hql, [agreementName: agreementName])
+      agreement_id = results.get(0)
+    }
+
+
+    return doPut("/erm/sas/${agreement_id}", {
+      items ([
+        {
+          resource {
+            id resourceId
+          }
+        }
+      ])
+    }) as Map
+  }
+
+  Pkg findPkgByPackageName(String packageName) {
+    log.info("Package name: " + packageName)
+    withTenant {
+      String hql = """
+            SELECT package
+            FROM Pkg package
+            WHERE package.name = :packageName
+        """
+      List results = Pkg.executeQuery(hql, [packageName: packageName])
+      if (results.size() > 1) {
+        throw new IllegalStateException("Multiple Packages found for package name ${packageName}, one expected.")
+      }
+      return results.get(0);
+    }
+  }
+
+  PackageContentItem findPCIByPackageName(String packageName, String titleName) {
+    withTenant {
+      String hql = """
+            SELECT pci
+            FROM PackageContentItem pci
+            WHERE pci.pkg.name = :packageName
+            AND pci.pti.titleInstance.work.title = :titleName
+        """
+      List results = PackageContentItem.executeQuery(hql, [packageName: packageName, titleName: titleName])
+      if (results.size() > 1) {
+        throw new IllegalStateException("Multiple PCIs found for package name ${packageName}, one expected.")
+      }
+      return results.get(0);
+    }
+  }
+
+  @Shared
+  String pciId;
+
+  @Shared
+  String ptiId;
+
+  @Shared
+  String tiId;
 
   void "Load Packages"() {
 
     when: 'File loaded'
     Map result = importPackageFromFileViaService('publicLookup/publicLookupPackage1.json')
+    importPackageFromFileViaService('publicLookup/publicLookupPackage2.json')
+    importPackageFromFileViaService('publicLookup/publicLookupPackage3.json')
     importPackageFromFileViaService('publicLookup/publicLookupPackage4.json')
+    importPackageFromFileViaService('publicLookup/publicLookupPackage5.json')
+    importPackageFromFileViaService('publicLookup/publicLookupPackage6.json')
     then: 'Package imported'
     result.packageImported == true
 
     when: "Looked up package with name"
     List resp = doGet("/erm/packages", [filters: ['name==test_package_1']])
+    doGet("/erm/packages", [filters: ['name==test_package_2']])
+    doGet("/erm/packages", [filters: ['name==test_package_3']])
     doGet("/erm/packages", [filters: ['name==test_package_4']])
+    doGet("/erm/packages", [filters: ['name==test_package_5']])
+    doGet("/erm/packages", [filters: ['name==test_package_6']])
     pkg_id = resp[0].id
 
     then: "Package found"
+    log.info(resp.toListString())
     resp.size() == 1
     resp[0].id != null
+  }
+
+  void "Create Agreements and lines"() {
+
+    when:
+    Pkg test_package_1 = findPkgByPackageName("test_package_1")
+    createAgreement("Agreement A")
+    addEntitlementForAgreement("Agreement A", test_package_1.id)
+
+    PackageContentItem test_package_1_pci = findPCIByPackageName("test_package_1", "Academy of Management Learning & Education")
+    createAgreement("Agreement B")
+    addEntitlementForAgreement("Agreement B", test_package_1_pci.id)
+
+    createAgreement("Agreement C")
+    Pkg test_package_6 = findPkgByPackageName("test_package_6")
+    addEntitlementForAgreement("Agreement C", test_package_6.id)
+
+    createAgreement("Agreement D")
+    PackageContentItem test_package_6_pci = findPCIByPackageName("test_package_6", "Academy of Management Learning & Education")
+    addEntitlementForAgreement("Agreement D", test_package_6_pci.id)
+
+    createAgreement("Agreement E")
+    Pkg test_package_2 = findPkgByPackageName("test_package_2")
+    addEntitlementForAgreement("Agreement E", test_package_2.id)
+
+    createAgreement("Agreement F")
+    PackageContentItem test_package_2_pci = findPCIByPackageName("test_package_2", "Academy of Management Learning & Education")
+    addEntitlementForAgreement("Agreement F", test_package_2_pci.id)
+
+    pciId = test_package_1_pci.id
+    ptiId = test_package_1_pci.pti.id
+    tiId = test_package_1_pci.pti.titleInstance.id
+
+    then:
+    Map res = doGet("/erm/sas")[0]
+    Map resEnt = doGet("/erm/entitlements")[0]
+    log.info("Logging")
+    log.info(res.toString())
+    log.info(resEnt.toString())
+
+    log.info("PCI ID: {}", pciId)
+    doGet("/erm/sas/publicLookup?resourceId=${pciId}").get("records").forEach{Object record -> log.info(record.name.toString())}
+
+    log.info("PTI ID: {}", ptiId)
+    doGet("/erm/sas/publicLookup?resourceId=${ptiId}").get("records").forEach{Object record -> log.info(record.name.toString())}
+
+    log.info("TI ID: {}", tiId)
+    doGet("/erm/sas/publicLookup?resourceId=${tiId}").get("records").forEach{Object record -> log.info(record.name.toString())}
+
+  }
+
+  void "Agreement B active to date in the past"() {
+
+    when:
+    String agreement_id;
+    withTenant {
+      String hql = """
+            SELECT agreement.id 
+            FROM SubscriptionAgreement agreement 
+            WHERE agreement.name = 'Agreement B'
+        """
+      List results = SubscriptionAgreement.executeQuery(hql)
+      agreement_id = results.get(0)
+    }
+
+    def today = LocalDate.now()
+    def dateInPast = today.minusDays(10)
+
+
+    doPut("/erm/sas/${agreement_id}", {
+      'activeTo' dateInPast
+    }) as Map
+
+    then:
+    List res = doGet("/erm/sas")
+    List resEnt = doGet("/erm/entitlements")
+    log.info("Logging")
+    log.info(res.toListString())
+    log.info(resEnt.toListString())
+
+    log.info("PCI ID: {}", pciId)
+    doGet("/erm/sas/publicLookup?resourceId=${pciId}").get("records").forEach{Object record -> log.info(record.name.toString())}
+
+    log.info("PTI ID: {}", ptiId)
+    doGet("/erm/sas/publicLookup?resourceId=${ptiId}").get("records").forEach{Object record -> log.info(record.name.toString())}
+
+    log.info("TI ID: {}", tiId)
+    doGet("/erm/sas/publicLookup?resourceId=${tiId}").get("records").forEach{Object record -> log.info(record.name.toString())}
+
   }
 }

--- a/service/src/integration-test/groovy/org/olf/Agreements/AgreementPublicLookupSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/Agreements/AgreementPublicLookupSpec.groovy
@@ -1,0 +1,28 @@
+package org.olf.Agreements
+import grails.testing.mixin.integration.Integration
+import org.olf.BaseSpec
+import spock.lang.Shared
+
+@Integration
+class AgreementPublicLookupSpec extends BaseSpec {
+  @Shared
+  String pkg_id
+
+  void "Load Packages"() {
+
+    when: 'File loaded'
+    Map result = importPackageFromFileViaService('publicLookup/publicLookupPackage1.json')
+    importPackageFromFileViaService('publicLookup/publicLookupPackage4.json')
+    then: 'Package imported'
+    result.packageImported == true
+
+    when: "Looked up package with name"
+    List resp = doGet("/erm/packages", [filters: ['name==test_package_1']])
+    doGet("/erm/packages", [filters: ['name==test_package_4']])
+    pkg_id = resp[0].id
+
+    then: "Package found"
+    resp.size() == 1
+    resp[0].id != null
+  }
+}

--- a/service/src/integration-test/groovy/org/olf/Agreements/AgreementsBaseSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/Agreements/AgreementsBaseSpec.groovy
@@ -1,0 +1,104 @@
+package org.olf.Agreements;
+
+import org.olf.BaseSpec
+import org.olf.erm.SubscriptionAgreement
+import org.olf.kb.PackageContentItem
+import org.olf.kb.Pkg
+import spock.lang.*
+
+import groovy.util.logging.Slf4j
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+@Slf4j
+@Stepwise
+abstract class AgreementsBaseSpec extends BaseSpec {
+  @Ignore
+  Map createAgreement(String name="test_agreement") {
+    def today = LocalDate.now()
+    def tomorrow = today.plusDays(1)
+
+    def payload = [
+      periods: [
+        [
+          startDate: today.format(DateTimeFormatter.ISO_LOCAL_DATE),
+          endDate: tomorrow.format(DateTimeFormatter.ISO_LOCAL_DATE)
+        ]
+      ],
+      name: name,
+      agreementStatus: "active"
+    ]
+
+    def response = doPost("/erm/sas/", payload)
+
+    return response as Map
+  }
+
+  @Ignore
+  Map addEntitlementForAgreement(String agreementName, String resourceId) {
+    String agreement_id;
+    withTenant {
+      String hql = """
+            SELECT agreement.id 
+            FROM SubscriptionAgreement agreement 
+            WHERE agreement.name = :agreementName 
+        """
+      List results = SubscriptionAgreement.executeQuery(hql, [agreementName: agreementName])
+      agreement_id = results.get(0)
+    }
+
+
+    return doPut("/erm/sas/${agreement_id}", {
+      items ([
+        {
+          resource {
+            id resourceId
+          }
+        }
+      ])
+    }) as Map
+  }
+
+  @Ignore
+  String getAgreementIdByName(String agreementName) {
+    String agreement_id;
+    withTenant {
+      String hql = """
+            SELECT agreement.id 
+            FROM SubscriptionAgreement agreement 
+            WHERE agreement.name = :agreementName 
+        """
+      List results = SubscriptionAgreement.executeQuery(hql, [agreementName: agreementName])
+      agreement_id = results.get(0)
+    }
+    return agreement_id
+  }
+
+  Pkg findPkgByPackageName(String packageName) {
+    log.info("Package name: " + packageName)
+    withTenant {
+      String hql = """
+            SELECT package
+            FROM Pkg package
+            WHERE package.name = :packageName
+        """
+      List results = Pkg.executeQuery(hql, [packageName: packageName])
+      return results.get(0);
+    }
+  }
+
+  PackageContentItem findPCIByPackageName(String packageName, String titleName) {
+    withTenant {
+      String hql = """
+            SELECT pci
+            FROM PackageContentItem pci
+            WHERE pci.pkg.name = :packageName
+            AND pci.pti.titleInstance.work.title = :titleName
+        """
+      List results = PackageContentItem.executeQuery(hql, [packageName: packageName, titleName: titleName])
+      return results.get(0);
+    }
+  }
+
+}

--- a/service/src/integration-test/resources/packages/publicLookup/publicLookupPackage1.json
+++ b/service/src/integration-test/resources/packages/publicLookup/publicLookupPackage1.json
@@ -1,0 +1,98 @@
+{
+  "header": {
+    "availability": {
+      "type": "general"
+    },
+    "packageProvider": {
+      "name": "Knowledge Integration Ltd"
+    },
+    "packageSource": "k-int",
+    "packageName": "test_package_1",
+    "startDate": "2015-01-01T00:00:00Z",
+    "endDate": "2020-12-31T00:00:00Z",
+    "packageSlug": "kint_test_001",
+    "_intenalId": 276432871386,
+    "availabilityScope": "Global",
+    "lifecycleStatus": "Current",
+    "syncContentsFromSource": true
+  },
+  "packageContents": [{
+    "title": "Academy of Management Learning & Education",
+    "instanceMedium": "electronic",
+    "instanceMedia": "journal",
+    "instanceIdentifiers": [{
+      "namespace": "eissn",
+      "value": "1944-9585"
+    }],
+    "siblingInstanceIdentifiers": [{
+      "namespace": "issn",
+      "value": "1537-260X"
+    },
+      {
+        "value": "2106015-0",
+        "namespace": "zdb"
+      }
+    ],
+    "coverage": [
+      {
+      "startVolume": "1",
+      "startIssue": "1",
+      "startDate": "2002-01-01",
+      "endVolume": "8",
+      "endIssue": "12",
+      "endDate": "2009-12-31"
+      },
+      {
+      "startVolume": "2",
+      "startIssue": "1",
+      "startDate": "2015-01-01",
+      "endVolume": null,
+      "endIssue": null,
+      "endDate": null
+      }
+    ],
+    "embargo": null,
+    "coverageDepth": "fulltext",
+    "coverageNote": "New for 2014. This record is a test case for split coverage",
+    "url": "http://aom.org/amle/",
+    "platformName": "Academy of Management",
+    "_platformId": 627,
+    "sourceIdentifierNamespace": "gokb",
+    "sourceIdentifier": "24134b52-05cd-47d3-ae4e-02d1e2d9c4fb"
+  },
+    {
+      "title": "The Personal History of David Copperfield",
+      "instanceMedium": "electronic",
+      "instanceMedia": "journal",
+      "instanceIdentifiers": [{
+        "namespace": "eissn",
+        "value": "9780141974330"
+      }],
+      "coverage": [
+        {
+          "startVolume": "1",
+          "startIssue": "1",
+          "startDate": "2002-01-01",
+          "endVolume": "8",
+          "endIssue": "12",
+          "endDate": "2009-12-31"
+        },
+        {
+          "startVolume": "2",
+          "startIssue": "1",
+          "startDate": "2015-01-01",
+          "endVolume": null,
+          "endIssue": null,
+          "endDate": null
+        }
+      ],
+      "embargo": null,
+      "coverageDepth": "fulltext",
+      "coverageNote": "New for 2014. This record is a test case for split coverage",
+      "url": "https://www.gutenberg.org/files/43111/43111-h/43111-h.htm",
+      "platformName": "Project Gutenberg",
+      "_platformId": 627,
+      "sourceIdentifierNamespace": "projectGutenberg",
+      "sourceIdentifier": "43111"
+    }]
+}

--- a/service/src/integration-test/resources/packages/publicLookup/publicLookupPackage1.json
+++ b/service/src/integration-test/resources/packages/publicLookup/publicLookupPackage1.json
@@ -58,7 +58,8 @@
     "platformName": "Academy of Management",
     "_platformId": 627,
     "sourceIdentifierNamespace": "gokb",
-    "sourceIdentifier": "24134b52-05cd-47d3-ae4e-02d1e2d9c4fb"
+    "sourceIdentifier": "24134b52-05cd-47d3-ae4e-02d1e2d9c4fb",
+    "accessStart": "2014-01-01"
   },
     {
       "title": "The Personal History of David Copperfield",
@@ -93,6 +94,7 @@
       "platformName": "Project Gutenberg",
       "_platformId": 627,
       "sourceIdentifierNamespace": "projectGutenberg",
-      "sourceIdentifier": "43111"
+      "sourceIdentifier": "43111",
+      "accessStart": "2020-01-01"
     }]
 }

--- a/service/src/integration-test/resources/packages/publicLookup/publicLookupPackage2.json
+++ b/service/src/integration-test/resources/packages/publicLookup/publicLookupPackage2.json
@@ -51,11 +51,12 @@
     "embargo": null,
     "coverageDepth": "fulltext",
     "coverageNote": "New for 2014. This record is a test case for split coverage",
-    "url": "http://aom.org/amle/",
+    "url": "http://aom.org/amle2/",
     "platformName": "Academy of Management",
     "_platformId": 627,
     "sourceIdentifierNamespace": "gokb",
-    "sourceIdentifier": "24134b52-05cd-47d3-ae4e-02d1e2d9c4fb"
+    "sourceIdentifier": "24134b52-05cd-47d3-ae4e-02d1e2d9c4fb",
+    "accessStart": "2099-01-01"
   },
     {
       "title": "The Personal History of David Copperfield",
@@ -90,6 +91,7 @@
       "platformName": "Project Gutenberg",
       "_platformId": 627,
       "sourceIdentifierNamespace": "projectGutenberg",
-      "sourceIdentifier": "43111"
+      "sourceIdentifier": "43111",
+      "accessStart": "2020-01-01"
     }]
 }

--- a/service/src/integration-test/resources/packages/publicLookup/publicLookupPackage2.json
+++ b/service/src/integration-test/resources/packages/publicLookup/publicLookupPackage2.json
@@ -10,7 +10,7 @@
     "packageName": "test_package_2",
     "startDate": "2015-01-01T00:00:00Z",
     "endDate": "2020-12-31T00:00:00Z",
-    "packageSlug": "kint_test_001",
+    "packageSlug": "kint_test_002",
     "_intenalId": 276432871386,
     "availabilityScope": "Global",
     "lifecycleStatus": "Current",

--- a/service/src/integration-test/resources/packages/publicLookup/publicLookupPackage2.json
+++ b/service/src/integration-test/resources/packages/publicLookup/publicLookupPackage2.json
@@ -1,0 +1,95 @@
+{
+  "header": {
+    "availability": {
+      "type": "general"
+    },
+    "packageProvider": {
+      "name": "Knowledge Integration Ltd"
+    },
+    "packageSource": "k-int",
+    "packageName": "test_package_2",
+    "startDate": "2015-01-01T00:00:00Z",
+    "endDate": "2020-12-31T00:00:00Z",
+    "packageSlug": "kint_test_001",
+    "_intenalId": 276432871386,
+    "availabilityScope": "Global",
+    "lifecycleStatus": "Current",
+    "syncContentsFromSource": true
+  },
+  "packageContents": [{
+    "title": "Academy of Management Learning & Education",
+    "instanceMedium": "electronic",
+    "instanceMedia": "journal",
+    "instanceIdentifiers": [{
+      "namespace": "eissn",
+      "value": "1944-9585"
+    }],
+    "siblingInstanceIdentifiers": [{
+      "namespace": "issn",
+      "value": "1537-260X"
+    },
+      {
+        "value": "2106015-0",
+        "namespace": "zdb"
+      }
+    ],
+    "coverage": [
+      {
+      "startVolume": "9",
+      "startIssue": "1",
+      "startDate": "2010-01-01"
+      },
+      {
+      "startVolume": "2",
+      "startIssue": "1",
+      "startDate": "2015-01-01",
+      "endVolume": null,
+      "endIssue": null,
+      "endDate": null
+      }
+    ],
+    "embargo": null,
+    "coverageDepth": "fulltext",
+    "coverageNote": "New for 2014. This record is a test case for split coverage",
+    "url": "http://aom.org/amle/",
+    "platformName": "Academy of Management",
+    "_platformId": 627,
+    "sourceIdentifierNamespace": "gokb",
+    "sourceIdentifier": "24134b52-05cd-47d3-ae4e-02d1e2d9c4fb"
+  },
+    {
+      "title": "The Personal History of David Copperfield",
+      "instanceMedium": "electronic",
+      "instanceMedia": "journal",
+      "instanceIdentifiers": [{
+        "namespace": "eissn",
+        "value": "9780141974330"
+      }],
+      "coverage": [
+        {
+          "startVolume": "1",
+          "startIssue": "1",
+          "startDate": "2002-01-01",
+          "endVolume": "8",
+          "endIssue": "12",
+          "endDate": "2009-12-31"
+        },
+        {
+          "startVolume": "2",
+          "startIssue": "1",
+          "startDate": "2015-01-01",
+          "endVolume": null,
+          "endIssue": null,
+          "endDate": null
+        }
+      ],
+      "embargo": null,
+      "coverageDepth": "fulltext",
+      "coverageNote": "New for 2014. This record is a test case for split coverage",
+      "url": "https://www.gutenberg.org/files/43111/43111-h/43111-h.htm",
+      "platformName": "Project Gutenberg",
+      "_platformId": 627,
+      "sourceIdentifierNamespace": "projectGutenberg",
+      "sourceIdentifier": "43111"
+    }]
+}

--- a/service/src/integration-test/resources/packages/publicLookup/publicLookupPackage3.json
+++ b/service/src/integration-test/resources/packages/publicLookup/publicLookupPackage3.json
@@ -1,0 +1,106 @@
+{
+  "header": {
+    "availability": {
+      "type": "general"
+    },
+    "packageProvider": {
+      "name": "Knowledge Integration Ltd"
+    },
+    "packageSource": "k-int",
+    "packageName": "test_package_3",
+    "startDate": "2015-01-01T00:00:00Z",
+    "endDate": "2020-12-31T00:00:00Z",
+    "packageSlug": "kint_test_003",
+    "_intenalId": 276432871388,
+    "availabilityScope": "Global",
+    "lifecycleStatus": "Current",
+    "syncContentsFromSource": false
+  },
+  "packageContents": [
+    {
+      "title": "Academy of Management Learning & Education",
+      "instanceMedium": "electronic",
+      "instanceMedia": "journal",
+      "instanceIdentifiers": [
+        {
+          "namespace": "eissn",
+          "value": "1944-9585"
+        }
+      ],
+      "siblingInstanceIdentifiers": [
+        {
+          "namespace": "issn",
+          "value": "1537-260X"
+        },
+        {
+          "value": "2106015-0",
+          "namespace": "zdb"
+        }
+      ],
+      "coverage": [
+        {
+          "startVolume": "1",
+          "startIssue": "1",
+          "startDate": "2002-01-01",
+          "endVolume": "8",
+          "endIssue": "12",
+          "endDate": "2009-12-31"
+        },
+        {
+          "startVolume": "2",
+          "startIssue": "1",
+          "startDate": "2015-01-01",
+          "endVolume": null,
+          "endIssue": null,
+          "endDate": null
+        }
+      ],
+      "embargo": "R10Y;P1M",
+      "coverageDepth": "fulltext",
+      "coverageNote": "New for 2014. This record is a test case for split coverage",
+      "url": "http://jstor.org/amle/",
+      "platformName": "JSTOR",
+      "_platformId": 627,
+      "sourceIdentifierNamespace": "gokb",
+      "sourceIdentifier": "24134b52-05cd-47d3-ae4e-02d1e2d9c4fb"
+    },
+    {
+      "title": "The Personal History of David Copperfield",
+      "instanceMedium": "electronic",
+      "instanceMedia": "journal",
+      "instanceIdentifiers": [
+        {
+          "namespace": "eissn",
+          "value": "9780141974330"
+        }
+      ],
+      "siblingInstanceIdentifiers": [],
+      "coverage": [
+        {
+          "startVolume": "1",
+          "startIssue": "1",
+          "startDate": "2002-01-01",
+          "endVolume": "8",
+          "endIssue": "12",
+          "endDate": "2009-12-31"
+        },
+        {
+          "startVolume": "2",
+          "startIssue": "1",
+          "startDate": "2015-01-01",
+          "endVolume": null,
+          "endIssue": null,
+          "endDate": null
+        }
+      ],
+      "embargo": null,
+      "coverageDepth": "full text",
+      "coverageNote": "New for 2014. This record is a test case for split coverage",
+      "url": "https://www.gutenberg.org/files/43111/43111-h/43111-h.htm",
+      "platformName": "Project Gutenberg",
+      "_platformId": 627,
+      "sourceIdentifierNamespace": "projectGutenberg",
+      "sourceIdentifier": "43111"
+    }
+  ]
+}

--- a/service/src/integration-test/resources/packages/publicLookup/publicLookupPackage3.json
+++ b/service/src/integration-test/resources/packages/publicLookup/publicLookupPackage3.json
@@ -62,7 +62,8 @@
       "platformName": "JSTOR",
       "_platformId": 627,
       "sourceIdentifierNamespace": "gokb",
-      "sourceIdentifier": "24134b52-05cd-47d3-ae4e-02d1e2d9c4fb"
+      "sourceIdentifier": "24134b52-05cd-47d3-ae4e-02d1e2d9c4fb",
+      "accessStart": "2014-01-01"
     },
     {
       "title": "The Personal History of David Copperfield",
@@ -100,7 +101,8 @@
       "platformName": "Project Gutenberg",
       "_platformId": 627,
       "sourceIdentifierNamespace": "projectGutenberg",
-      "sourceIdentifier": "43111"
+      "sourceIdentifier": "43111",
+      "accessStart": "2020-01-01"
     }
   ]
 }

--- a/service/src/integration-test/resources/packages/publicLookup/publicLookupPackage4.json
+++ b/service/src/integration-test/resources/packages/publicLookup/publicLookupPackage4.json
@@ -1,0 +1,64 @@
+{
+  "header": {
+    "availability": {
+      "type": "general"
+    },
+    "packageProvider": {
+      "name": "Knowledge Integration Ltd"
+    },
+    "packageSource": "k-int",
+    "packageName": "test_package_4",
+    "startDate": "2015-01-01T00:00:00Z",
+    "endDate": "2020-12-31T00:00:00Z",
+    "packageSlug": "kint_test_004",
+    "_intenalId": 276432871389,
+    "availabilityScope": "Global",
+    "lifecycleStatus": "Current",
+    "syncContentsFromSource": false
+  },
+  "packageContents": [
+    {
+      "title": "Academy of Management Journal",
+      "instanceMedium": "electronic",
+      "instanceMedia": "journal",
+      "instanceIdentifiers": [
+        {
+          "namespace": "eissn",
+          "value": "1948-0989"
+        }
+      ],
+      "siblingInstanceIdentifiers": [
+        {
+          "namespace": "issn",
+          "value": "0001-4273"
+        }
+      ],
+      "coverage": [
+        {
+          "startVolume": "1",
+          "startIssue": "1",
+          "startDate": "2002-01-01",
+          "endVolume": "8",
+          "endIssue": "12",
+          "endDate": "2009-12-31"
+        },
+        {
+          "startVolume": "2",
+          "startIssue": "1",
+          "startDate": "2015-01-01",
+          "endVolume": null,
+          "endIssue": null,
+          "endDate": null
+        }
+      ],
+      "embargo": null,
+      "coverageDepth": "fulltext",
+      "coverageNote": "New for 2014. This record is a test case for split coverage",
+      "url": "http://aom.org/amj/",
+      "platformName": "Academy of Management",
+      "_platformId": 627,
+      "sourceIdentifierNamespace": "gokb",
+      "sourceIdentifier": "def0ba15-4215-4630-a90f-4671e524fc09"
+    }
+  ]
+}

--- a/service/src/integration-test/resources/packages/publicLookup/publicLookupPackage5.json
+++ b/service/src/integration-test/resources/packages/publicLookup/publicLookupPackage5.json
@@ -1,0 +1,97 @@
+{
+  "header": {
+    "availability": {
+      "type": "general"
+    },
+    "packageProvider": {
+      "name": "Knowledge Integration Ltd"
+    },
+    "packageSource": "k-int",
+    "packageName": "test_package_5",
+    "startDate": "2015-01-01T00:00:00Z",
+    "endDate": "2020-12-31T00:00:00Z",
+    "packageSlug": "kint_test_005",
+    "_intenalId": 276432871390,
+    "availabilityScope": "Global",
+    "lifecycleStatus": "Current",
+    "syncContentsFromSource": false
+  },
+  "packageContents": [
+    {
+      "title": "The Personal History of David Copperfield",
+      "instanceMedium": "electronic",
+      "instanceMedia": "journal",
+      "instanceIdentifiers": [
+        {
+          "namespace": "eissn",
+          "value": "9780141974330"
+        }
+      ],
+      "siblingInstanceIdentifiers": [],
+      "coverage": [
+        {
+          "startVolume": "1",
+          "startIssue": "1",
+          "startDate": "2002-01-01",
+          "endVolume": "8",
+          "endIssue": "12",
+          "endDate": "2009-12-31"
+        },
+        {
+          "startVolume": "2",
+          "startIssue": "1",
+          "startDate": "2015-01-01",
+          "endVolume": null,
+          "endIssue": null,
+          "endDate": null
+        }
+      ],
+      "embargo": null,
+      "coverageDepth": "full text",
+      "coverageNote": "New for 2014. This record is a test case for split coverage",
+      "url": "https://www.gutenberg.org/files/43111/43111-h/43111-h.htm",
+      "platformName": "Project Gutenberg",
+      "_platformId": 627,
+      "sourceIdentifierNamespace": "projectGutenberg",
+      "sourceIdentifier": "43111"
+    },
+    {
+      "title": "The Personal History of David Copperfield",
+      "instanceMedium": "electronic",
+      "instanceMedia": "journal",
+      "instanceIdentifiers": [
+        {
+          "namespace": "eissn",
+          "value": "9780141974331"
+        }
+      ],
+      "siblingInstanceIdentifiers": [],
+      "coverage": [
+        {
+          "startVolume": "1",
+          "startIssue": "1",
+          "startDate": "2002-01-01",
+          "endVolume": "8",
+          "endIssue": "12",
+          "endDate": "2009-12-31"
+        },
+        {
+          "startVolume": "2",
+          "startIssue": "1",
+          "startDate": "2015-01-01",
+          "endVolume": null,
+          "endIssue": null,
+          "endDate": null
+        }
+      ],
+      "embargo": null,
+      "coverageDepth": "full text",
+      "coverageNote": "New for 2014. This record is a test case for split coverage",
+      "url": "https://www.gutenberg.org/files/431112/431112-h/431112-h.htm",
+      "platformName": "Project Gutenberg",
+      "_platformId": 627,
+      "sourceIdentifierNamespace": "projectGutenberg",
+      "sourceIdentifier": "43111"
+    }
+  ]
+}

--- a/service/src/integration-test/resources/packages/publicLookup/publicLookupPackage5.json
+++ b/service/src/integration-test/resources/packages/publicLookup/publicLookupPackage5.json
@@ -91,7 +91,8 @@
       "platformName": "Project Gutenberg",
       "_platformId": 627,
       "sourceIdentifierNamespace": "projectGutenberg",
-      "sourceIdentifier": "43111"
+      "sourceIdentifier": "43111",
+      "accessStart": "2020-01-01"
     }
   ]
 }

--- a/service/src/integration-test/resources/packages/publicLookup/publicLookupPackage6.json
+++ b/service/src/integration-test/resources/packages/publicLookup/publicLookupPackage6.json
@@ -62,7 +62,9 @@
       "platformName": "Academy of Management",
       "_platformId": 627,
       "sourceIdentifierNamespace": "gokb",
-      "sourceIdentifier": "24134b52-05cd-47d3-ae4e-02d1e2d9c4fb"
+      "sourceIdentifier": "24134b52-05cd-47d3-ae4e-02d1e2d9c4fb",
+      "accessStart": "2014-01-01",
+      "accessEnd": "2020-12-31"
     },
     {
       "title": "The Personal History of David Copperfield",
@@ -100,7 +102,9 @@
       "platformName": "Project Gutenberg",
       "_platformId": 627,
       "sourceIdentifierNamespace": "projectGutenberg",
-      "sourceIdentifier": "43111"
+      "sourceIdentifier": "43111",
+      "accessStart": "2020-01-01",
+      "accessEnd": "2020-12-31"
     }
   ]
 }

--- a/service/src/integration-test/resources/packages/publicLookup/publicLookupPackage6.json
+++ b/service/src/integration-test/resources/packages/publicLookup/publicLookupPackage6.json
@@ -1,0 +1,106 @@
+{
+  "header": {
+    "availability": {
+      "type": "general"
+    },
+    "packageProvider": {
+      "name": "Knowledge Integration Ltd"
+    },
+    "packageSource": "k-int",
+    "packageName": "test_package_6",
+    "startDate": "2015-01-01T00:00:00Z",
+    "endDate": "2020-12-31T00:00:00Z",
+    "packageSlug": "kint_test_006",
+    "_intenalId": 276432871391,
+    "availabilityScope": "Global",
+    "lifecycleStatus": "Current",
+    "syncContentsFromSource": true
+  },
+  "packageContents": [
+    {
+      "title": "Academy of Management Learning & Education",
+      "instanceMedium": "electronic",
+      "instanceMedia": "journal",
+      "instanceIdentifiers": [
+        {
+          "namespace": "eissn",
+          "value": "1944-9585"
+        }
+      ],
+      "siblingInstanceIdentifiers": [
+        {
+          "namespace": "issn",
+          "value": "1537-260X"
+        },
+        {
+          "value": "2106015-0",
+          "namespace": "zdb"
+        }
+      ],
+      "coverage": [
+        {
+          "startVolume": "1",
+          "startIssue": "1",
+          "startDate": "2002-01-01",
+          "endVolume": "8",
+          "endIssue": "12",
+          "endDate": "2009-12-31"
+        },
+        {
+          "startVolume": "2",
+          "startIssue": "1",
+          "startDate": "2015-01-01",
+          "endVolume": null,
+          "endIssue": null,
+          "endDate": null
+        }
+      ],
+      "embargo": null,
+      "coverageDepth": "fulltext",
+      "coverageNote": "New for 2014. This record is a test case for split coverage",
+      "url": "http://aom.org/amle/",
+      "platformName": "Academy of Management",
+      "_platformId": 627,
+      "sourceIdentifierNamespace": "gokb",
+      "sourceIdentifier": "24134b52-05cd-47d3-ae4e-02d1e2d9c4fb"
+    },
+    {
+      "title": "The Personal History of David Copperfield",
+      "instanceMedium": "electronic",
+      "instanceMedia": "journal",
+      "instanceIdentifiers": [
+        {
+          "namespace": "eissn",
+          "value": "9780141974330"
+        }
+      ],
+      "siblingInstanceIdentifiers": [],
+      "coverage": [
+        {
+          "startVolume": "1",
+          "startIssue": "1",
+          "startDate": "2002-01-01",
+          "endVolume": "8",
+          "endIssue": "12",
+          "endDate": "2009-12-31"
+        },
+        {
+          "startVolume": "2",
+          "startIssue": "1",
+          "startDate": "2015-01-01",
+          "endVolume": null,
+          "endIssue": null,
+          "endDate": null
+        }
+      ],
+      "embargo": null,
+      "coverageDepth": "full text",
+      "coverageNote": "New for 2014. This record is a test case for split coverage",
+      "url": "https://www.gutenberg.org/files/43111/43111-h/43111-h.htm",
+      "platformName": "Project Gutenberg",
+      "_platformId": 627,
+      "sourceIdentifierNamespace": "projectGutenberg",
+      "sourceIdentifier": "43111"
+    }
+  ]
+}


### PR DESCRIPTION
- Adds integration tests based on scenarios in ticket: https://folio-org.atlassian.net/browse/ERM-3726?atlOrigin=eyJpIjoiMWM4YmY5ZGE2MzBiNDdjMzk1ZWM3YTI1M2VlODZjMGMiLCJwIjoiaiJ9
- Makes a second fix to the publicLookup method (should this be a separate PR/ticket? - the error was found while writing integration tests). The error we noticed was that a PCI which is **directly** added as an entitlement to an agreement should be returned by the publicLookup API even if it lies outside the accessStart and accessEnd dates. It is only when the PCI is returned indirectly by the API because it is part of a package, that the filtering based on accessStart and accessEnd dates should be applied. The fix was to remove the accessStart and accessEnd filters on the **direct** PCI part of the query. Query filters remain for accessStart and accessEnd dates for a PKG_PCI, and a directly attached PCI is still filtered based on the activeFrom and activeTo fields. 
- Added to the /Agreements integration tests, so should already be included in CI.