### PR TITLE
ERM-3757: Package Deletion: Add Query Parameter for ids in delete response

### DIFF
--- a/service/src/integration-test/groovy/org/olf/DeleteResources/NegativeTestSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/DeleteResources/NegativeTestSpec.groovy
@@ -53,7 +53,7 @@ class NegativeTestSpec extends DeletionBaseSpec {
     when:
     Map operationResponse
     Set<String> expectedPcis = findInputResourceIds(["PCI1"] as List, "simple")
-    String endpoint = "/erm/resource/delete/pci"
+    String endpoint = "/erm/resource/delete/pci?includeIds=true"
     List<String> idsForProcessing = ["thisIdDoesNotExist", expectedPcis[0]]
     operationResponse = doPost(endpoint, [resources: idsForProcessing])
 
@@ -74,7 +74,7 @@ class NegativeTestSpec extends DeletionBaseSpec {
     when:
     Map operationResponse
     Set<String> Pti = findInputResourceIds(["PTI1"] as List, "simple")
-    String endpoint = "/erm/resource/delete/pci"
+    String endpoint = "/erm/resource/delete/pci?includeIds=true"
     List<String> idsForProcessing = [Pti[0]]
     operationResponse = doPost(endpoint, [resources: idsForProcessing])
 

--- a/service/src/integration-test/groovy/org/olf/DeleteResources/ResourceDeletionSpec.groovy
+++ b/service/src/integration-test/groovy/org/olf/DeleteResources/ResourceDeletionSpec.groovy
@@ -133,7 +133,7 @@ class ResourceDeletionSpec extends DeletionBaseSpec {
 
     // Only make a call if there are IDs to process for the designated resource type
     if (!testCase.resourceTypeToMark.isEmpty() && !idsForProcessing.isEmpty()) {
-      String endpoint = "/erm/resource/markForDelete/${testCase.resourceTypeToMark}" // e.g., /pci, /pti, /ti
+      String endpoint = "/erm/resource/markForDelete/${testCase.resourceTypeToMark}?includeIds=true" // IncludeIds flag is required for tests.
       String payloadKey = "resources"
       operationResponse = doPost(endpoint, [(payloadKey): idsForProcessing])
     } else {

--- a/service/src/main/groovy/org/olf/kb/http/response/PackageMarkForDeleteResponse.groovy
+++ b/service/src/main/groovy/org/olf/kb/http/response/PackageMarkForDeleteResponse.groovy
@@ -1,0 +1,9 @@
+package org.olf.kb.http.response
+
+import org.olf.kb.http.response.DeletionCounts
+import org.olf.kb.http.response.MarkForDeleteResponse
+
+class PackageMarkForDeleteResponse {
+  Map<String, MarkForDeleteResponse> packages = [:]
+  DeletionCounts statistics = new DeletionCounts()
+}


### PR DESCRIPTION
- Introduces a "includeIds" boolean parameter check.
- If includeIds is false, the resourceDeletion controller methods call hideIds() on the response object, which sets the resourceIds property to null on both MarkForDeleteResponse and DeleteResponse objects.