### PR TITLE
ERM-3734: sourceTitleCount in package schema header does not update

### DIFF
--- a/service/grails-app/services/org/olf/PackageIngestService.groovy
+++ b/service/grails-app/services/org/olf/PackageIngestService.groovy
@@ -333,6 +333,14 @@ AccessEnd/${result.updatedAccessEnd}\
         pkg.availabilityScopeFromString = package_data.header.availabilityScope
       }
 
+      if (package_data.header.sourceTitleCount) {
+        pkg.sourceTitleCount = package_data.header.sourceTitleCount
+      }
+
+      if (package_data.header.sourceDataCreated) {
+        pkg.sourceDataCreated = package_data.header.sourceDataCreated
+      }
+
       // DO NOT UPDATE syncContentsFromSource.
 
       pkg.vendor = vendor


### PR DESCRIPTION
Comments here: https://folio-org.atlassian.net/browse/ERM-3734?focusedCommentId=269735

Tested that new package update works by changing values in pgAdmin and re-running the package ingest, and by changing values for manual package import.

Identifiers and other list/set fields mentioned in discussion and the ticket seem to have the expected behaviour.