### PR TITLE
ERM-3768: Change job name used for package deletion

### DIFF
--- a/service/grails-app/services/org/olf/ErmResourceService.groovy
+++ b/service/grails-app/services/org/olf/ErmResourceService.groovy
@@ -413,7 +413,7 @@ public class ErmResourceService {
   @CompileStatic(SKIP)
   public createDeleteResourcesJob(List<String> idInputs, ResourceDeletionJobType type) {
     ResourceDeletionJob job = new ResourceDeletionJob([
-      name: "ResourceDeletionJob, resource IDs: ${idInputs.toString()} ${Instant.now()}",
+      name: "Deletion Job: ${type.toString()} for ${idInputs.size().toString()} resources. ${Instant.now()}",
       resourceInputs: new JSON(idInputs).toString(), // Should always be a list of strings for now.
       deletionJobType: type
     ])


### PR DESCRIPTION
Example output.

```
{
  "id": "796a3000-ec65-4523-9877-514a260e4c2c",
  "deletionJobType": "PackageDeletionJob",
  "dateCreated": 1752667484537,
  "resourceInputs": "[\"28f8dbb1-50a8-464b-ac60-432ac60832e9\",\"09f0137f-6e20-4a85-82b4-4450ceab99a7\",\"d9b3617b-4ebe-4d74-8f83-78a2d4d3ea55\",\"b799b4b6-845b-4049-9963-d3d9cc06303a\",\"f77013f8-fc13-41a9-8eff-fff240395997\",\"433c1082-156c-45aa-b804-f47b25334649\"]",
  "name": "Deletion Job: PackageDeletionJob for 6 resources. 2025-07-16T12:04:44.506747377Z",
  "status": {
    "id": "ff80818198125e0c0198125e7d3b0049"
  }
}
```