### PR TITLE
ERM-3765: Agreements allows deletion of reference data values that are in use

### DIFF
--- a/service/grails-app/domain/org/olf/kb/Pkg.groovy
+++ b/service/grails-app/domain/org/olf/kb/Pkg.groovy
@@ -82,8 +82,8 @@ public class Pkg extends ErmResource implements MultiTenant<Pkg> {
                        vendor(nullable:true, blank:false)
             sourceDataCreated(nullable:true, blank:false)
             sourceDataUpdated(nullable:true, blank:false)
-              lifecycleStatus(nullable:true, blank:false)
-            availabilityScope(nullable:true, blank:false)
+              lifecycleStatus(nullable:true, blank:false) // TODO - do we actually want this to be nullable?
+            availabilityScope(nullable:true, blank:false) // TODO - do we actually want this to be nullable?
   }
 
   /*

--- a/service/grails-app/migrations/module-tenant-changelog.groovy
+++ b/service/grails-app/migrations/module-tenant-changelog.groovy
@@ -37,4 +37,5 @@ databaseChangeLog = {
   include file: 'update-mod-agreements-7-2.groovy'
   include file: 'add-missing-primary-keys-for-trillium.groovy'
   include file: 'update-mod-agreements-7-3.groovy'
+  include file: 'update-mod-agreements-7-4.groovy'
 }

--- a/service/grails-app/migrations/update-mod-agreements-7-4.groovy
+++ b/service/grails-app/migrations/update-mod-agreements-7-4.groovy
@@ -1,22 +1,17 @@
 databaseChangeLog = {
   changeSet(author: "mchaib (manual)", id: "20250716-1620-001") {
-    // Create a refDataCategory
-//    grailsChange {
-//      change {
-//        sql.execute("INSERT INTO ${database.defaultSchemaName}.refdata_category (rdc_id, rdc_version, rdc_description) SELECT md5(random()::text || clock_timestamp()::text) as id, 0 as version, 'SubscriptionAgreement.ReasonForClosure' as description WHERE NOT EXISTS (SELECT rdc_description FROM ${database.defaultSchemaName}.refdata_category WHERE (rdc_description)=('SubscriptionAgreement.ReasonForClosure') LIMIT 1);".toString())
-//      }
-//    }
-
-    // Create the "Missing" refDataValue for LifecycleStatus category
+    // Create the "missingLifecycleStatusRefDataValue" refDataValue for LifecycleStatus category
     grailsChange {
       change {
         sql.execute("INSERT INTO ${database.defaultSchemaName}.refdata_value (rdv_id, rdv_version, rdv_value, rdv_owner, rdv_label) SELECT md5(random()::text || clock_timestamp()::text) as id, 0 as version, 'missingLifecycleStatusRefDataValue' as value, (SELECT rdc_id FROM  ${database.defaultSchemaName}.refdata_category WHERE rdc_description='Pkg.LifecycleStatus') as owner, 'missingLifecycleStatusRefDataValue' as label WHERE NOT EXISTS (SELECT rdv_id FROM ${database.defaultSchemaName}.refdata_value INNER JOIN ${database.defaultSchemaName}.refdata_category ON refdata_value.rdv_owner = refdata_category.rdc_id WHERE rdc_description='Pkg.LifecycleStatus' AND rdv_value='missingLifecycleStatusRefDataValue' LIMIT 1);".toString())
       }
     }
 
-
-//    sql.execute("UPDATE ${database.defaultSchemaName}.package SET pkg_lifecycle_status_fk='test2'".toString())
-    grailsChange {
+    /*
+    Get the newly created 'missingLifecycleStatusRefDataValue' ID from the refDataValue table and set the pkg_lifecycle_status_fk
+    column to that ID where the value currently in the pkg_lifecycle_status_fk DOES NOT CURRENTLY EXIST in the refDataValue table (where block below).
+    */
+   grailsChange {
       change {
         sql.execute("""
           UPDATE ${database.defaultSchemaName}.package
@@ -39,16 +34,45 @@ databaseChangeLog = {
       }
     }
 
-    // Create the "Missing" refDataValue for AvailabilityScope category
+    // Create the "missingAvailabilityScopeRefDataValue" refDataValue for AvailabilityScope category
     grailsChange {
       change {
         sql.execute("INSERT INTO ${database.defaultSchemaName}.refdata_value (rdv_id, rdv_version, rdv_value, rdv_owner, rdv_label) SELECT md5(random()::text || clock_timestamp()::text) as id, 0 as version, 'missingAvailabilityScopeRefDataValue' as value, (SELECT rdc_id FROM  ${database.defaultSchemaName}.refdata_category WHERE rdc_description='Pkg.AvailabilityScope') as owner, 'missingAvailabilityScopeRefDataValue' as label WHERE NOT EXISTS (SELECT rdv_id FROM ${database.defaultSchemaName}.refdata_value INNER JOIN ${database.defaultSchemaName}.refdata_category ON refdata_value.rdv_owner = refdata_category.rdc_id WHERE rdc_description='Pkg.AvailabilityScope' AND rdv_value='missingAvailabilityScopeRefDataValue' LIMIT 1);".toString())
       }
     }
+
+    /*
+    Get the newly created 'missingAvailabilityScopeRefDataValue' ID from the refDataValue table and set the pkg_availability_scope_fk
+    column to that ID where the value currently in the pkg_availability_scope_fk DOES NOT CURRENTLY EXIST in the refDataValue table (where block below).
+    */
+    grailsChange {
+      change {
+        sql.execute("""
+          UPDATE ${database.defaultSchemaName}.package
+          SET
+            pkg_availability_scope_fk = (
+              SELECT ${database.defaultSchemaName}.refdata_value.rdv_id
+              FROM ${database.defaultSchemaName}.refdata_value
+              INNER JOIN ${database.defaultSchemaName}.refdata_category ON ${database.defaultSchemaName}.refdata_value.rdv_owner = ${database.defaultSchemaName}.refdata_category.rdc_id
+              WHERE ${database.defaultSchemaName}.refdata_category.rdc_description = 'Pkg.AvailabilityScope'
+                AND ${database.defaultSchemaName}.refdata_value.rdv_value = 'missingAvailabilityScopeRefDataValue'
+              LIMIT 1
+            )
+          WHERE
+            NOT EXISTS (
+              SELECT 1
+              FROM ${database.defaultSchemaName}.refdata_value
+              WHERE ${database.defaultSchemaName}.refdata_value.rdv_id = ${database.defaultSchemaName}.package.pkg_availability_scope_fk
+            )
+        """.toString())
+      }
+    }
   }
 
-//  changeSet(author: "mchaib (manual)", id: "20250716-1620-002") {
-//    addForeignKeyConstraint(baseColumnNames: "pkg_lifecycle_status_fk", baseTableName: "package", constraintName: "lifecycle_status_to_rdv_fk", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
-//    addForeignKeyConstraint(baseColumnNames: "pkg_availability_scope_fk", baseTableName: "package", constraintName: "availability_scope_to_rdv_fk", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
-//  }
+  // Now that both the pkg_lifecycle_status_fk and pkg_availability_scope_fk columns are always referencing existing values in rdv table,
+  // Create the foreign key constraints on these columns so when a refDataValue is in use by a package, the refDataValue can't be deleted.
+  changeSet(author: "mchaib (manual)", id: "20250716-1620-002") {
+    addForeignKeyConstraint(baseColumnNames: "pkg_lifecycle_status_fk", baseTableName: "package", constraintName: "lifecycle_status_to_rdv_fk", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
+    addForeignKeyConstraint(baseColumnNames: "pkg_availability_scope_fk", baseTableName: "package", constraintName: "availability_scope_to_rdv_fk", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
+  }
 }

--- a/service/grails-app/migrations/update-mod-agreements-7-4.groovy
+++ b/service/grails-app/migrations/update-mod-agreements-7-4.groovy
@@ -1,0 +1,6 @@
+databaseChangeLog = {
+  changeSet(author: "mchaib (manual)", id: "20250710-1620-001") {
+    addForeignKeyConstraint(baseColumnNames: "pkg_lifecycle_status_fk", baseTableName: "package", constraintName: "lifecycle_status_to_rdv_fk", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
+    addForeignKeyConstraint(baseColumnNames: "pkg_availability_scope_fk", baseTableName: "package", constraintName: "availability_scope_to_rdv_fk", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
+  }
+}

--- a/service/grails-app/migrations/update-mod-agreements-7-4.groovy
+++ b/service/grails-app/migrations/update-mod-agreements-7-4.groovy
@@ -1,5 +1,20 @@
 databaseChangeLog = {
   changeSet(author: "mchaib (manual)", id: "20250716-1620-001") {
+    // create the Pkg.LifecycleStatus category if it doesn't already exist
+    grailsChange {
+      change {
+        sql.execute("INSERT INTO ${database.defaultSchemaName}.refdata_category (rdc_id, rdc_version, rdc_description, internal) SELECT md5(random()::text || clock_timestamp()::text) as id, 0 as version, 'Pkg.LifecycleStatus' as description, false as internal WHERE NOT EXISTS (SELECT rdc_description FROM ${database.defaultSchemaName}.refdata_category WHERE (rdc_description)=('Pkg.LifecycleStatus') LIMIT 1);".toString())
+      }
+    }
+
+    // create the Pkg.AvailabilityScope category if it doesn't already exist
+    grailsChange {
+      change {
+        sql.execute("INSERT INTO ${database.defaultSchemaName}.refdata_category (rdc_id, rdc_version, rdc_description, internal) SELECT md5(random()::text || clock_timestamp()::text) as id, 0 as version, 'Pkg.AvailabilityScope' as description, false as internal WHERE NOT EXISTS (SELECT rdc_description FROM ${database.defaultSchemaName}.refdata_category WHERE (rdc_description)=('Pkg.AvailabilityScope') LIMIT 1);".toString())
+      }
+    }
+
+
     // Create the "missingLifecycleStatusRefDataValue" refDataValue for LifecycleStatus category
     grailsChange {
       change {

--- a/service/grails-app/migrations/update-mod-agreements-7-4.groovy
+++ b/service/grails-app/migrations/update-mod-agreements-7-4.groovy
@@ -1,6 +1,54 @@
 databaseChangeLog = {
-  changeSet(author: "mchaib (manual)", id: "20250710-1620-001") {
-    addForeignKeyConstraint(baseColumnNames: "pkg_lifecycle_status_fk", baseTableName: "package", constraintName: "lifecycle_status_to_rdv_fk", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
-    addForeignKeyConstraint(baseColumnNames: "pkg_availability_scope_fk", baseTableName: "package", constraintName: "availability_scope_to_rdv_fk", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
+  changeSet(author: "mchaib (manual)", id: "20250716-1620-001") {
+    // Create a refDataCategory
+//    grailsChange {
+//      change {
+//        sql.execute("INSERT INTO ${database.defaultSchemaName}.refdata_category (rdc_id, rdc_version, rdc_description) SELECT md5(random()::text || clock_timestamp()::text) as id, 0 as version, 'SubscriptionAgreement.ReasonForClosure' as description WHERE NOT EXISTS (SELECT rdc_description FROM ${database.defaultSchemaName}.refdata_category WHERE (rdc_description)=('SubscriptionAgreement.ReasonForClosure') LIMIT 1);".toString())
+//      }
+//    }
+
+    // Create the "Missing" refDataValue for LifecycleStatus category
+    grailsChange {
+      change {
+        sql.execute("INSERT INTO ${database.defaultSchemaName}.refdata_value (rdv_id, rdv_version, rdv_value, rdv_owner, rdv_label) SELECT md5(random()::text || clock_timestamp()::text) as id, 0 as version, 'missingLifecycleStatusRefDataValue' as value, (SELECT rdc_id FROM  ${database.defaultSchemaName}.refdata_category WHERE rdc_description='Pkg.LifecycleStatus') as owner, 'missingLifecycleStatusRefDataValue' as label WHERE NOT EXISTS (SELECT rdv_id FROM ${database.defaultSchemaName}.refdata_value INNER JOIN ${database.defaultSchemaName}.refdata_category ON refdata_value.rdv_owner = refdata_category.rdc_id WHERE rdc_description='Pkg.LifecycleStatus' AND rdv_value='missingLifecycleStatusRefDataValue' LIMIT 1);".toString())
+      }
+    }
+
+
+//    sql.execute("UPDATE ${database.defaultSchemaName}.package SET pkg_lifecycle_status_fk='test2'".toString())
+    grailsChange {
+      change {
+        sql.execute("""
+          UPDATE ${database.defaultSchemaName}.package
+          SET
+            pkg_lifecycle_status_fk = (
+              SELECT ${database.defaultSchemaName}.refdata_value.rdv_id
+              FROM ${database.defaultSchemaName}.refdata_value
+              INNER JOIN ${database.defaultSchemaName}.refdata_category ON ${database.defaultSchemaName}.refdata_value.rdv_owner = ${database.defaultSchemaName}.refdata_category.rdc_id
+              WHERE ${database.defaultSchemaName}.refdata_category.rdc_description = 'Pkg.LifecycleStatus'
+                AND ${database.defaultSchemaName}.refdata_value.rdv_value = 'missingLifecycleStatusRefDataValue'
+              LIMIT 1
+            )
+          WHERE
+            NOT EXISTS (
+              SELECT 1
+              FROM ${database.defaultSchemaName}.refdata_value
+              WHERE ${database.defaultSchemaName}.refdata_value.rdv_id = ${database.defaultSchemaName}.package.pkg_lifecycle_status_fk
+            )
+        """.toString())
+      }
+    }
+
+    // Create the "Missing" refDataValue for AvailabilityScope category
+    grailsChange {
+      change {
+        sql.execute("INSERT INTO ${database.defaultSchemaName}.refdata_value (rdv_id, rdv_version, rdv_value, rdv_owner, rdv_label) SELECT md5(random()::text || clock_timestamp()::text) as id, 0 as version, 'missingAvailabilityScopeRefDataValue' as value, (SELECT rdc_id FROM  ${database.defaultSchemaName}.refdata_category WHERE rdc_description='Pkg.AvailabilityScope') as owner, 'missingAvailabilityScopeRefDataValue' as label WHERE NOT EXISTS (SELECT rdv_id FROM ${database.defaultSchemaName}.refdata_value INNER JOIN ${database.defaultSchemaName}.refdata_category ON refdata_value.rdv_owner = refdata_category.rdc_id WHERE rdc_description='Pkg.AvailabilityScope' AND rdv_value='missingAvailabilityScopeRefDataValue' LIMIT 1);".toString())
+      }
+    }
   }
+
+//  changeSet(author: "mchaib (manual)", id: "20250716-1620-002") {
+//    addForeignKeyConstraint(baseColumnNames: "pkg_lifecycle_status_fk", baseTableName: "package", constraintName: "lifecycle_status_to_rdv_fk", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
+//    addForeignKeyConstraint(baseColumnNames: "pkg_availability_scope_fk", baseTableName: "package", constraintName: "availability_scope_to_rdv_fk", deferrable: "false", initiallyDeferred: "false", referencedColumnNames: "rdv_id", referencedTableName: "refdata_value")
+//  }
 }


### PR DESCRIPTION
I've tested this by starting up mod-agreements using the master-branch schema and dropping tenant. Then, I load in the packages and delete the "current" refDataValue for lifecycleStatus and "global" rdv for availabilityScope. I then run a diagnostic SQL query to check that some packages are indeed now pointing to the missing refDataValues. I then create the migration and run trigger-migrations, and check the packages table again and see that now all packages that were previously referencing "null" values in availabilityScope or lifecycleStatus are now pointing at the new "missingAvailabilityScope..."  values.

Finally, I go back to Bruno and try to delete a refDataValue for the lifecycleStatus or availabilityScope categories, and it fails because of the foreign key constraint. So think this is a success.