### PR TITLE
ERM-3763: Package markForDelete can give incorrect outcome when specifying multiple packages

### DIFF
--- a/service/grails-app/controllers/org/olf/ResourceController.groovy
+++ b/service/grails-app/controllers/org/olf/ResourceController.groovy
@@ -470,7 +470,7 @@ class ResourceController extends OkapiTenantAwareController<ErmResource> {
     Boolean includeIds = params.boolean('includeIds')
 
     handleDeleteCall(deleteBody) { ids ->
-      PackageMarkForDeleteResponse response = ermResourceService.markForDeleteFromPackage(ids)
+      MarkForDeleteResponse response = ermResourceService.markForDeleteFromPackage(ids)
       if (!includeIds) {
         response = hideIds(response)
       }

--- a/service/grails-app/services/org/olf/ErmResourceService.groovy
+++ b/service/grails-app/services/org/olf/ErmResourceService.groovy
@@ -392,7 +392,7 @@ public class ErmResourceService {
   @CompileStatic(SKIP)
   public createDeleteResourcesJob(List<String> idInputs, ResourceDeletionJobType type) {
     ResourceDeletionJob job = new ResourceDeletionJob([
-      name: "ResourceDeletionJob, resource IDs: ${idInputs.size().toString()} ${Instant.now()}",
+      name: "ResourceDeletionJob, resource IDs: ${idInputs?.size()?.toString()} ${Instant.now()}",
       resourceInputs: new JSON(idInputs).toString(), // Should always be a list of strings for now.
       deletionJobType: type
     ])

--- a/service/grails-app/services/org/olf/ErmResourceService.groovy
+++ b/service/grails-app/services/org/olf/ErmResourceService.groovy
@@ -383,37 +383,16 @@ public class ErmResourceService {
   }
 
   // Mark a list of package IDs for delete and aggregate responses into one output Map.
-  // Also combine statistics for all packages.
-  public Map markForDeleteFromPackage(List<String> idInputs) {
-    Map<String, MarkForDeleteResponse> deleteResourcesResponseMap = [:]
+  public MarkForDeleteResponse markForDeleteFromPackage(List<String> idInputs) {
 
-    // Collect responses for each package in a Map.
-    idInputs.forEach{String id -> {
-      MarkForDeleteResponse forDeletion = markForDelete([id], Pkg.class); // Finds all PCIs for package and deletes as though the PCI Ids were passed in.
-      deleteResourcesResponseMap.put(id, forDeletion)
-    }}
-
-    // Calculate total deletion counts
-    DeletionCounts totals = new DeletionCounts(0,0,0,0)
-    deleteResourcesResponseMap.keySet().forEach{String packageId -> {
-      totals.pci += deleteResourcesResponseMap.get(packageId).statistics.pci
-      totals.pti += deleteResourcesResponseMap.get(packageId).statistics.pti
-      totals.ti += deleteResourcesResponseMap.get(packageId).statistics.ti
-      totals.work += deleteResourcesResponseMap.get(packageId).statistics.work
-    }}
-
-    Map outputMap = [:]
-
-    outputMap.put("packages", deleteResourcesResponseMap)
-    outputMap.put("statistics", totals)
-
-    return outputMap;
+    // Collect responses for all packages passed in.
+    return markForDelete(idInputs, Pkg.class);
   }
 
   @CompileStatic(SKIP)
   public createDeleteResourcesJob(List<String> idInputs, ResourceDeletionJobType type) {
     ResourceDeletionJob job = new ResourceDeletionJob([
-      name: "ResourceDeletionJob, resource IDs: ${idInputs.toString()} ${Instant.now()}",
+      name: "ResourceDeletionJob, resource IDs: ${idInputs.size().toString()} ${Instant.now()}",
       resourceInputs: new JSON(idInputs).toString(), // Should always be a list of strings for now.
       deletionJobType: type
     ])


### PR DESCRIPTION
MarkForDelete for the package endpoint now passes in the PCIs from all packages at once, which ensures that the correct numbers are shown. However, this means that we only show the total statistics for all packages being deleted, rather than a breakdown.


This response originally:
```
{
  "packages": {
    "09f0137f-6e20-4a85-82b4-4450ceab99a7": {
      "statistics": {
        "ti": 7419,
        "pci": 5000,
        "work": 4993,
        "pti": 5000
      }
    },
    "433c1082-156c-45aa-b804-f47b25334649": {
      "statistics": {
        "ti": 21371,
        "pci": 10827,
        "work": 10827,
        "pti": 10827
      }
    },
    "b799b4b6-845b-4049-9963-d3d9cc06303a": {
      "statistics": {
        "ti": 11815,
        "pci": 6119,
        "work": 6119,
        "pti": 6119
      }
    },
    "d9b3617b-4ebe-4d74-8f83-78a2d4d3ea55": {
      "statistics": {
        "ti": 9360,
        "pci": 4680,
        "work": 4680,
        "pti": 4680
      }
    },
    "f77013f8-fc13-41a9-8eff-fff240395997": {
      "statistics": {
        "ti": 20551,
        "pci": 10576,
        "work": 10569,
        "pti": 10576
      }
    }
  },
  "statistics": {
    "pci": 37202,
    "pti": 37202,
    "ti": 70516,
    "work": 37188
  }
}
```

Becomes this response (can still include pci/pti/ti/work counts using ?includeIds=True):

```
{
  "statistics": {
    "pci": 37202,
    "pti": 37202,
    "ti": 70530,
    "work": 37195
  }
}
```