### PR TITLE
chore: add comments to domain properties that are missing from tables

### DIFF
--- a/service/grails-app/domain/org/olf/kb/Pkg.groovy
+++ b/service/grails-app/domain/org/olf/kb/Pkg.groovy
@@ -38,6 +38,7 @@ public class Pkg extends ErmResource implements MultiTenant<Pkg> {
   
   // Declaring this here will provide defaults for the type defined in ErmResource but not create
   // a subclass specific column
+  // NOTE: This column does not exist on the Pkg table in the database, so we shouldn't try and reference it.
   @Defaults(['Aggregated Full Text', 'Abstracts and Index', 'Package'])
   RefdataValue type
 

--- a/service/grails-app/domain/org/olf/kb/TitleInstance.groovy
+++ b/service/grails-app/domain/org/olf/kb/TitleInstance.groovy
@@ -50,17 +50,20 @@ public class TitleInstance extends ErmResource implements MultiTenant<TitleInsta
   
   // For grouping sibling title instances together - EG Print and Electronic editions of the same thing
   Work work
-  
+
   // Journal/Book/...
+  // NOTE: This column does not exist on the TitleInstance table in the database, so we shouldn't try and reference it.
   @CategoryId(defaultInternal=false)
   RefdataValue publicationType
 
   // serial / monograph system
+  // NOTE: This column does not exist on the TitleInstance table in the database, so we shouldn't try and reference it.
   @CategoryId(defaultInternal=true)
   @Defaults(['Monograph', 'Serial'])
   RefdataValue type
 
   // Print/Electronic
+  // NOTE: This column does not exist on the TitleInstance table in the database, so we shouldn't try and reference it.
   @CategoryId(defaultInternal=true)
   @Defaults(['Print', 'Electronic'])
   RefdataValue subType


### PR DESCRIPTION
As discussed when looking at the refDataValue audit.