### PR TITLE
fix: access control stream cancelled

### DIFF
--- a/service/grails-app/controllers/com/k_int/accesscontrol/grails/PolicyEngineController.groovy
+++ b/service/grails-app/controllers/com/k_int/accesscontrol/grails/PolicyEngineController.groovy
@@ -66,7 +66,7 @@ class PolicyEngineController<T> extends OkapiTenantAwareController<T> {
     // I'm not convinced this is the best way to do it but hey ho
     UserDetails patron = getPatron()
     String defaultPatronId = 'defaultPatronId'
-    if (patron.id != null) {
+    if (patron.hasProperty("id")) {
       defaultPatronId = patron.id
     }
     log.trace("defaultPatronId: ${defaultPatronId}")

--- a/service/grails-app/controllers/com/k_int/accesscontrol/grails/PolicyEngineController.groovy
+++ b/service/grails-app/controllers/com/k_int/accesscontrol/grails/PolicyEngineController.groovy
@@ -66,7 +66,7 @@ class PolicyEngineController<T> extends OkapiTenantAwareController<T> {
     // I'm not convinced this is the best way to do it but hey ho
     UserDetails patron = getPatron()
     String defaultPatronId = 'defaultPatronId'
-    if (patron.hasProperty("id")) {
+    if (patron.id != null) {
       defaultPatronId = patron.id
     }
     log.trace("defaultPatronId: ${defaultPatronId}")

--- a/service/src/main/java/com/k_int/folio/FolioClient.java
+++ b/service/src/main/java/com/k_int/folio/FolioClient.java
@@ -109,7 +109,8 @@ public class FolioClient {
     this.tenant = tenant;
     this.httpClient = HttpClient.newBuilder()
         .connectTimeout(Duration.ofSeconds(10))
-        .executor(FolioClientExecutor.getHttpClientExecutor())
+        // TODO I am not at all convinced I know what I'm doing here... leave it off for now
+        //.executor(FolioClientExecutor.getHttpClientExecutor())
         .version(HttpClient.Version.HTTP_1_1)
         .build();
 

--- a/service/src/main/java/com/k_int/folio/FolioClient.java
+++ b/service/src/main/java/com/k_int/folio/FolioClient.java
@@ -109,6 +109,8 @@ public class FolioClient {
     this.tenant = tenant;
     this.httpClient = HttpClient.newBuilder()
         .connectTimeout(Duration.ofSeconds(10))
+        .executor(FolioClientExecutor.getHttpClientExecutor())
+        .version(HttpClient.Version.HTTP_1_1)
         .build();
 
     this.patronId = patronId;

--- a/service/src/main/java/com/k_int/folio/FolioClient.java
+++ b/service/src/main/java/com/k_int/folio/FolioClient.java
@@ -111,7 +111,7 @@ public class FolioClient {
         .connectTimeout(Duration.ofSeconds(10))
         // TODO I am not at all convinced I know what I'm doing here... leave it off for now
         //.executor(FolioClientExecutor.getHttpClientExecutor())
-        .version(HttpClient.Version.HTTP_1_1)
+        .version(HttpClient.Version.HTTP_1_1) // This seems to resolve issues with stream cancellations
         .build();
 
     this.patronId = patronId;

--- a/service/src/main/java/com/k_int/folio/FolioClientBodyHandler.java
+++ b/service/src/main/java/com/k_int/folio/FolioClientBodyHandler.java
@@ -78,23 +78,23 @@ public class FolioClientBodyHandler<T> implements HttpResponse.BodyHandler<T> {
 
       if (targetType.equals(String.class)) {
         // If the target type is String, we can directly return a BodySubscriber that reads the body as a String
-        return getInputStreamBodySubscriber();
+        return getStringBodySubscriber();
       }
 
       if (targetType.equals(InputStream.class)) {
         // If the target type is String, we can directly return a BodySubscriber that reads the body as a String
-        return getStringBodySubscriber();
+        return getInputStreamBodySubscriber();
       }
 
       // If successful, we want to deserialize the body
       return HttpResponse.BodySubscribers.mapping(
         HttpResponse.BodySubscribers.ofInputStream(),
         inputStream -> {
-          try (InputStream is = inputStream) { // Ensure stream is closed
-            if (is == null) {
-              return null;
-            }
-            return objectMapper.readValue(is, targetType);
+          if (inputStream == null) {
+            return null;
+          }
+          try {
+            return objectMapper.readValue(inputStream, targetType);
           } catch (IOException e) {
             String errorMessage = "Failed to deserialize response body to " + targetType.getSimpleName();
             log.error(errorMessage, e);

--- a/service/src/main/java/com/k_int/folio/FolioClientExecutor.java
+++ b/service/src/main/java/com/k_int/folio/FolioClientExecutor.java
@@ -5,6 +5,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+
+// FIXME This was conceived as an attempt to fix stream cancellations, but changing to HTTP1.1 did that
+// Knowing then that this is slightly out of my depth right now, I am putting this class' use on hold
 public class FolioClientExecutor {
 
   private static final int HTTP_CLIENT_POOL_SIZE = 20; // Example size

--- a/service/src/main/java/com/k_int/folio/FolioClientExecutor.java
+++ b/service/src/main/java/com/k_int/folio/FolioClientExecutor.java
@@ -1,0 +1,38 @@
+package com.k_int.folio;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class FolioClientExecutor {
+
+  private static final int HTTP_CLIENT_POOL_SIZE = 20; // Example size
+
+  // Use a private static final to ensure it's a singleton and managed centrally
+  private static final ExecutorService HTTP_CLIENT_EXECUTOR =
+    new ThreadPoolExecutor(
+      HTTP_CLIENT_POOL_SIZE, // corePoolSize
+      HTTP_CLIENT_POOL_SIZE, // maximumPoolSize (fixed size pool)
+      0L, TimeUnit.MILLISECONDS, // keepAliveTime
+      new java.util.concurrent.LinkedBlockingQueue<>(), // unbounded queue for tasks
+      Executors.defaultThreadFactory() // default thread factory
+    );
+
+  public static void shutdownExecutor() {
+    HTTP_CLIENT_EXECUTOR.shutdown(); // Initiates an orderly shutdown
+    try {
+      if (!HTTP_CLIENT_EXECUTOR.awaitTermination(60, TimeUnit.SECONDS)) {
+        HTTP_CLIENT_EXECUTOR.shutdownNow(); // Force shutdown if not terminated gracefully
+      }
+    } catch (InterruptedException e) {
+      HTTP_CLIENT_EXECUTOR.shutdownNow();
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  // You'll need to expose this executor
+  public static ExecutorService getHttpClientExecutor() {
+    return HTTP_CLIENT_EXECUTOR;
+  }
+}


### PR DESCRIPTION
When making calls off to acquisition units we get hit with "stream cancelled" exceptions when the thread pool gets over saturated. This is clearly not great, leading to 500s in the UI where things mostly work in the API layer


To attempt to combat this, ensure the Http version is 1.1 not 2, as the latter seems to cause issues




I had set an explicit thread pool for the FolioClient, but I don't know what I'm doing well enough there, so this is provisionally turned off, awaiting some help and explanations.