### PR TITLE
ERM-3888 Sunflower back-port: commons-fileupload 1.6.0 fixing CVE

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -164,6 +164,8 @@ dependencies {
 
   implementation 'com.opencsv:opencsv:5.7.1'
   implementation 'commons-io:commons-io:2.14.0'
+  // security upgrade for commons-fileupload CVE-2025-48976 https://github.com/advisories/GHSA-vv7r-c36w-3prj
+  implementation 'commons-fileupload:commons-fileupload:1.6.0'
   // Grails 5 and up no longer supports groovy files for logback config
   implementation('io.github.virtualdogbert:logback-groovy-config:1.14.1')
   compileOnly 'ch.qos.logback:logback-classic:1.4.7'


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/ERM-3888

Back-port #964 from master to Sunflower branch `release/7.2.x`:

Upgrade commons-fileupload from 1.5 to 1.6.0.

This fixes: Allocation of resources for multipart headers with insufficient limits enabled a DoS vulnerability https://github.com/advisories/GHSA-vv7r-c36w-3prj = CVE-2025-48976

(cherry picked from commit abc5b20e68032329896cdd2bd24ff35e36e50b4b)