### PR TITLE
ERM-4023. Ensure `resourceName` always included in entitlement response

### DIFF
--- a/service/grails-app/views/entitlement/_externalEntitlement.gson
+++ b/service/grails-app/views/entitlement/_externalEntitlement.gson
@@ -64,9 +64,7 @@ json {
   'note' entitlement.note
   'docs'  g.render(entitlement.docs)
 
-  if (entitlement.getAuthority()?.toLowerCase() == Entitlement.GOKB_RESOURCE_AUTHORITY.toLowerCase()) {
   'resourceName' entitlement.getResourceName()
-  }
   
   if (renderOwnerSnippet) {
     'owner' g.render(entitlement.owner, [includes: ['id', 'name']])


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/ERM-4023

The _externalEntitlement.gson view previously only rendered the resourceName
property when the entitlement's authority was GOKB-RESOURCE. As a result, the
field was silently omitted from external entitlement responses for other
authorities (e.g. EKB-TITLE, EKB-PACKAGE), even though resourceName is a
general persistent column on Entitlement that can be populated regardless of
authority.

This PR removes that conditional so resourceName is always included in the
external entitlement response — rendered with its current value, or null when
unset.